### PR TITLE
feat: Add a 'start level' field to page tree plugin for menu generation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,17 +14,11 @@ repos:
   hooks:
     - id: isort
       name: isort (python)
-- repo: https://github.com/ambv/black
-  rev: 21.12b0
-  hooks:
-  - id: black
-    language_version: python3.9
 - repo: https://gitlab.com/pycqa/flake8
   rev: 3.9.2
   hooks:
     - id: flake8
       additional_dependencies:
-        - flake8-black
         - flake8-bugbear
         - flake8-builtins
         - flake8-django

--- a/djangocms_frontend/contrib/navigation/cms_plugins.py
+++ b/djangocms_frontend/contrib/navigation/cms_plugins.py
@@ -75,7 +75,7 @@ class PageTreePlugin(
     fieldsets = [
         (
             None,
-            {"fields": ("template",)},
+            {"fields": ("start_level", "template",)},
         ),
     ]
 
@@ -83,6 +83,10 @@ class PageTreePlugin(
         return get_plugin_template(
             instance, "navigation", "page_tree", settings.NAVIGATION_TEMPLATE_CHOICES
         )
+
+    def render(self, context, instance, placeholder):
+        context['start_level'] = instance.config.get("start_level", 0)
+        return super().render(context, instance, placeholder)
 
 
 @plugin_pool.register_plugin

--- a/djangocms_frontend/contrib/navigation/forms.py
+++ b/djangocms_frontend/contrib/navigation/forms.py
@@ -67,11 +67,17 @@ class PageTreeForm(mixin_factory("PageTree"), EntangledModelForm):
         model = FrontendUIItem
         entangled_fields = {
             "config": [
+                "start_level",
                 "template",
                 "attributes",
             ]
         }
         untangled_fields = ()
+
+    start_level = forms.IntegerField(
+        initial=0,
+        help_text=_("Start level for the menu tag")
+    )
 
     template = forms.ChoiceField(
         label=_("Template"),

--- a/djangocms_frontend/contrib/navigation/forms.py
+++ b/djangocms_frontend/contrib/navigation/forms.py
@@ -75,6 +75,7 @@ class PageTreeForm(mixin_factory("PageTree"), EntangledModelForm):
         untangled_fields = ()
 
     start_level = forms.IntegerField(
+        label=_("Start level"),
         initial=0,
         help_text=_("Start level for the menu tag")
     )

--- a/djangocms_frontend/contrib/navigation/templates/djangocms_frontend/bootstrap5/navigation/default/page_tree.html
+++ b/djangocms_frontend/contrib/navigation/templates/djangocms_frontend/bootstrap5/navigation/default/page_tree.html
@@ -1,1 +1,1 @@
-{% load menu_tags %}{% show_menu 0 100 0 100 'djangocms_frontend/bootstrap5/navigation/default/menu.html' %}
+{% load menu_tags %}{% show_menu start_level 100 0 100 'djangocms_frontend/bootstrap5/navigation/default/menu.html' %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,7 +12,6 @@
 # serve to show the default.
 
 # fmt: off
-import os
 import sys
 from pathlib import Path
 


### PR DESCRIPTION
This adds a "start level" from which to render the menu for the page tree plugin.