### PR TITLE
fix: Added template field to nav container

### DIFF
--- a/djangocms_frontend/contrib/navigation/cms_plugins.py
+++ b/djangocms_frontend/contrib/navigation/cms_plugins.py
@@ -136,7 +136,7 @@ class NavContainerPlugin(
     fieldsets = [
         (
             None,
-            {"fields": ()},
+            {"fields": ("template",)},
         ),
     ]
 

--- a/djangocms_frontend/contrib/navigation/forms.py
+++ b/djangocms_frontend/contrib/navigation/forms.py
@@ -108,11 +108,20 @@ class NavContainerForm(mixin_factory("NavContainer"), EntangledModelForm):
         model = FrontendUIItem
         entangled_fields = {
             "config": [
+                "template",
                 "attributes",
             ]
         }
         untangled_fields = ()
 
+    template = forms.ChoiceField(
+        label=_("Template"),
+        choices=settings.NAVIGATION_TEMPLATE_CHOICES,
+        initial=first_choice(settings.NAVIGATION_TEMPLATE_CHOICES),
+        widget=forms.HiddenInput
+        if len(settings.NAVIGATION_TEMPLATE_CHOICES) < 2
+        else forms.Select,
+    )
     attributes = AttributesFormField()
 
 


### PR DESCRIPTION
The nav container template can't currently be changed from the default. This adds the template field to the form.

The nav link also has this problem.