### PR TITLE
ci: Lint PR title to ensure conventional commit

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,20 @@
+name: "Lint PR"
+
+# Validates PR titles against the conventional commit spec
+# https://github.com/commitizen/conventional-commit-types
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I've taken this from a workflow I added to django-cms.

This checks the title of PRs to ensure that they match conventional commits.

https://www.conventionalcommits.org/en/v1.0.0-beta.2/