### PR TITLE
feat: Add support for Django 4.0

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -17,7 +17,7 @@ jobs:
             dj32_cms38.txt,
             dj32_cms39.txt,
             dj32_cms40.txt,
-            # dj40_cms311.txt,
+            dj40_cms311.txt,
         ]
         os: [
             ubuntu-20.04,

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 from djangocms_frontend import __version__
 
 REQUIREMENTS = [
-    "Django>=2.2,<4",
+    "Django>=2.2,<4.1",
     "django-cms>=3.7",
     "django-filer>=1.7",
     "djangocms-attributes-field>=1",

--- a/tests/requirements/dj40_cms311.txt
+++ b/tests/requirements/dj40_cms311.txt
@@ -1,6 +1,5 @@
 -r base.txt
 
--e git+https://github.com/fsbraun/django-filer.git@master#egg=django-filer
-
+django-filer>=2.2
 Django>=4.0,<4.1
--e git+https://github.com/django-cms/django-cms.git@develop#egg=django-cms
+django-cms>=3.11


### PR DESCRIPTION
Tests pass and dependencies support it, so it looks like there's no reason to exclude Django 4.0.