### PR TITLE
fix: Image plugin linked to deleted ``filer.Image`` object.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Unreleased
 * Fix dark mode for select2 widget
 * Fix lint errors in scss files
 * removed forms app
+* Fix for ``Image`` plugin where the associated ``filer.Image`` has been deleted.
 
 0.9.4
 =====


### PR DESCRIPTION
This fixes issue where an `Image` plugin is linked to a `filer.Image` object which has been deleted.

The result of this change is that instead of the page throwing a 500 error on the `ValueError` from `easy_thumbnails`, you get "file is missing" in the structure pane and the field appears empty in the form.

![Screenshot 2022-09-14 at 14 54 22](https://user-images.githubusercontent.com/1461191/190174281-979f1b19-30d0-48fe-bf87-4034780faf2c.png)
