### PR TITLE
fix: LinkForm does not inherit from mixin_factory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,33 +4,33 @@ ci:
 
         for more information, see https://pre-commit.ci
     autofix_prs: false
-    autoupdate_commit_msg: 'ci: pre-commit autoupdate'
+    autoupdate_commit_msg: "ci: pre-commit autoupdate"
     autoupdate_schedule: monthly
 
 repos:
-- repo: https://github.com/asottile/pyupgrade
-  rev: v3.3.1
-  hooks:
-    - id: pyupgrade
-      args: [ "--py37-plus" ]
-- repo: https://github.com/adamchainz/django-upgrade
-  rev: '1.12.0'
-  hooks:
-    - id: django-upgrade
-      args: [ --target-version, "2.2" ]
-- repo: https://github.com/pycqa/isort
-  rev: 5.11.4
-  hooks:
-    - id: isort
-      name: isort (python)
-- repo: https://github.com/PyCQA/flake8
-  rev: 6.0.0
-  hooks:
-    - id: flake8
-      additional_dependencies:
-        - flake8-bugbear
-        - flake8-builtins
-        - flake8-django
-        - flake8-length
-        - flake8-logging-format
-        - flake8-spellcheck
+    - repo: https://github.com/asottile/pyupgrade
+      rev: v3.3.1
+      hooks:
+          - id: pyupgrade
+            args: ["--py37-plus"]
+    - repo: https://github.com/adamchainz/django-upgrade
+      rev: "1.12.0"
+      hooks:
+          - id: django-upgrade
+            args: [--target-version, "2.2"]
+    - repo: https://github.com/pycqa/isort
+      rev: 5.12.0
+      hooks:
+          - id: isort
+            name: isort (python)
+    - repo: https://github.com/PyCQA/flake8
+      rev: 6.0.0
+      hooks:
+          - id: flake8
+            additional_dependencies:
+                - flake8-bugbear
+                - flake8-builtins
+                - flake8-django
+                - flake8-length
+                - flake8-logging-format
+                - flake8-spellcheck

--- a/djangocms_frontend/contrib/link/forms.py
+++ b/djangocms_frontend/contrib/link/forms.py
@@ -27,8 +27,11 @@ from ...fields import (
 )
 from ...helpers import first_choice, get_related_object
 from ...models import FrontendUIItem
+from .. import link
 from .constants import LINK_CHOICES, LINK_SIZE_CHOICES, TARGET_CHOICES
 from .helpers import get_choices, get_object_for_value
+
+mixin_factory = settings.get_forms(link)
 
 # Weak dependency on djangocms_icon
 # (Even if djangocms_icon is in the python path, the admin form will fail due to missing
@@ -298,7 +301,7 @@ else:
                         )
 
 
-class LinkForm(SpacingFormMixin, TemplateChoiceMixin, AbstractLinkForm):
+class LinkForm(mixin_factory("Link"), SpacingFormMixin, TemplateChoiceMixin, AbstractLinkForm):
     class Meta:
         model = FrontendUIItem
         entangled_fields = {


### PR DESCRIPTION
LinkPlugin can not be extended using a theme module. 
The root of the problem is that  `LinkForm` is not inheriting from a mixin obtained by the mixin_factory.

 fixes #95
