### PR TITLE
feat: Enable custom migration modules

### DIFF
--- a/djangocms_frontend/management/bootstrap4_migration.py
+++ b/djangocms_frontend/management/bootstrap4_migration.py
@@ -517,3 +517,5 @@ data_migration = {
         x, y, "DJANGOCMS_BOOTSTRAP4_CAROUSEL_TEMPLATES", "DJANGOCMS_FRONTEND_CAROUSEL_TEMPLATES"
     ),
 }
+
+plugin_prefix = "Bootstrap4"

--- a/djangocms_frontend/management/commands/subcommands/migrate.py
+++ b/djangocms_frontend/management/commands/subcommands/migrate.py
@@ -1,3 +1,4 @@
+import importlib
 from django.apps import apps
 from django.conf import settings
 from django.db import connection, models
@@ -9,6 +10,7 @@ plugin_names = {}
 
 plugin_migrations = {}
 data_migration = {}
+plugin_prefixes = []
 
 # Bootstrap 4
 if "djangocms_bootstrap4" in apps.all_models:
@@ -16,12 +18,30 @@ if "djangocms_bootstrap4" in apps.all_models:
 
     plugin_migrations.update(bootstrap4_migration.plugin_migrations)
     data_migration.update(bootstrap4_migration.data_migration)
+    plugin_prefixes.append(bootstrap4_migration.plugin_prefix)
 # Styled link
 if "djangocms_styledlink" in apps.all_models:
     from djangocms_frontend.management import styled_link_migration
 
     plugin_migrations.update(styled_link_migration.plugin_migrations)
     data_migration.update(styled_link_migration.data_migration)
+    plugin_prefixes.append(styled_link_migration.plugin_prefix)
+
+additional_migrations = getattr(
+    settings, "DJANGOCMS_FRONTEND_ADDITIONAL_MIGRATIONS", None
+)
+if additional_migrations:
+    if isinstance(additional_migrations, str):
+        additional_migrations = [additional_migrations]
+
+    for migration_module_path in additional_migrations:
+        try:
+            migration_module = importlib.import_module(migration_module_path)
+            plugin_migrations.update(migration_module.plugin_migrations)
+            data_migration.update(migration_module.data_migration)
+            plugin_prefixes.append(migration_module.plugin_prefix)
+        except ModuleNotFoundError:
+            print(f"Warning: can not import migration module: {migration_module_path}.")
 
 
 def migrate_to_djangocms_frontend(apps, schema_editor):
@@ -158,12 +178,13 @@ class Migrate(SubcommandsCommand):
 
     def migrate_to_djangocms_frontend(self):
         from cms.models.pluginmodel import CMSPlugin
+
         self.stdout.write(self.style.SUCCESS("Migrating plugins"))
         self.stdout.write(self.style.SUCCESS("================="))
         changes = migrate_to_djangocms_frontend(apps, None)
         not_migrated = []
         for plugin in CMSPlugin.objects.all():
-            if "Bootstrap4" in plugin.plugin_type:
+            if any([prefix in plugin.plugin_type for prefix in plugin_prefixes]):
                 if plugin.plugin_type not in not_migrated:
                     not_migrated.append(plugin.plugin_type)
                     self.stdout.write(

--- a/djangocms_frontend/management/commands/subcommands/migrate.py
+++ b/djangocms_frontend/management/commands/subcommands/migrate.py
@@ -1,4 +1,5 @@
 import importlib
+
 from django.apps import apps
 from django.conf import settings
 from django.db import connection, models

--- a/djangocms_frontend/management/styled_link_migration.py
+++ b/djangocms_frontend/management/styled_link_migration.py
@@ -84,3 +84,5 @@ data_migration = {
     "S001": s001_migrate_styled_link,
     "S002": s002_migrate_image_container,
 }
+
+plugin_prefix = "StyledLink"

--- a/docs/source/howto_guides.rst
+++ b/docs/source/howto_guides.rst
@@ -473,3 +473,29 @@ If you already have your own ``change_form_template``, make sure it extends
     {% block ...%}
         ...
     {% endblock %}
+
+*************************************
+ How to migrate other plugin packages
+*************************************
+
+The management command ``migrate`` converts any plugin from **djangocms_bootstrap4**
+and **djangocms_styled_link** to **djangocms-frontend**.
+This behaviour can be extended adding custom migratation modules to
+the ``DJANGOCMS_FRONTEND_ADDITIONAL_MIGRATIONS`` setting.
+
+A migration module must contain this three objects:
+
+plugin_migrations
+    Dictionary with the configuration of migration process for
+    each plugin class.
+
+data_migration
+    Dictionary with methods to transform attributes of the plugins.
+
+plugin_prefix
+    String with the prefix of the plugin_types that are being migrated.
+    The migration process alerts if there are remaining plugins with
+    this prefix.
+
+Check the source code of ``management/bootstrap4_migration.py`` to get
+more details about this three objects.

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -380,6 +380,8 @@ project directory. ``command`` can be one of the following:
 ``migrate``
     Migrates plugins from other frontend packages to **djangocms-frontend**.
     Currently supports **djangocms_bootstrap4** and **djangocms_styled_link**.
+    Other packages can be migrated adding custom migration modules to
+    the ``DJANGOCMS_FRONTEND_ADDITIONAL_MIGRATIONS`` setting.
 
 ``stale_references``
     If references in a UI item are moved or removed the UI items are designed to


### PR DESCRIPTION
The management command migrate will include any custom migration module configured in the DJANGOCMS_FRONTEND_ADDITIONAL_MIGRATIONS setting in order to add more plugin 
classes/packages to the migration process to djangocms-frontend plugins.