### PR TITLE
Use `bg-body` for tab navigation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ unpublished
 ===========
 
 * Fix bug where url for link select2 field was lost after app hook reload (#135)
+* Use `bg-body` class on Bootstrap 5's tab navigation to support color modes (#138)
 
 1.1.4 (2023-05-28)
 ==================

--- a/djangocms_frontend/contrib/tabs/frameworks/bootstrap5.py
+++ b/djangocms_frontend/contrib/tabs/frameworks/bootstrap5.py
@@ -15,7 +15,7 @@ class TabItemRenderMixin:
             else:
                 instance.add_classes("border")
         if context["parent"].tab_type == "nav-tabs":
-            instance.add_classes("bg-white")
+            instance.add_classes("bg-body")
         if parent.tab_index == context["parentloop"]["counter"]:
             instance.add_classes("show active")
         return super().render(context, instance, placeholder)


### PR DESCRIPTION
In order to support Bootstrap color modes `bg-white` should be avoided.