### PR TITLE
fix: Set proper image target link in template

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+unpublished
+===========
+
+* Fix bug: set proper image target link in template
+
 1.1.6 (2023-07-26)
 ==================
 

--- a/djangocms_frontend/contrib/image/templates/djangocms_frontend/bootstrap5/default/image.html
+++ b/djangocms_frontend/contrib/image/templates/djangocms_frontend/bootstrap5/default/image.html
@@ -1,7 +1,7 @@
 {% load thumbnail frontend %}{% spaceless %}
     {% if picture_link %}
         <a href="{{ picture_link }}"
-            {% if instance.link_target %} target="{{ instance.link_target }}"{% endif %}
+            {% if instance.target %} target="{{ instance.target }}"{% endif %}
             {% get_attributes instance.link_attributes %}>
     {% endif %}
     <img src="{{ instance.img_src }}" {% if not instance.attributes.alt and instance.rel_image.default_alt_text %}alt="{{ instance.rel_image.default_alt_text }}"{% endif %} {% if instance.width %} width="{{ instance.width|safe }}"{% endif %} {% if instance.height %} height="{{ instance.height|safe }}"{% endif %}


### PR DESCRIPTION
We saw that even when selecting the "open in a new window" (or tab) option, the template was not displaying the `target="_blank"` attribute in the link of an image plugin.

That's because the template is using `instance.link_target` instead of `instance.target`, so I fixed that in the template :)