### PR TITLE
fix: Keep aspect ratio of uploaded images if only one of `width` or `height` is set.

### DIFF
--- a/djangocms_frontend/contrib/image/models.py
+++ b/djangocms_frontend/contrib/image/models.py
@@ -30,10 +30,11 @@ class ImageMixin:
 
         # calculate height when not given according to the
         # golden ratio or fallback to the image size
+        picture_ratio = self.rel_image.width / self.rel_image.height if self.rel_image else PICTURE_RATIO
         if not height and width:
-            height = width / PICTURE_RATIO
+            height = width / picture_ratio
         elif not width and height:
-            width = height * PICTURE_RATIO
+            width = height * picture_ratio
         elif not width and not height and getattr(self, "picture", None):
             if self.rel_image:
                 width = self.rel_image.width
@@ -47,6 +48,7 @@ class ImageMixin:
             width, height = 640, 640 / PICTURE_RATIO
         width = int(width)
         height = int(height)
+        print(f"===> ({width=}, {height=})")
         return {
             "size": (width, height),
             "crop": crop,

--- a/djangocms_frontend/contrib/image/models.py
+++ b/djangocms_frontend/contrib/image/models.py
@@ -48,7 +48,6 @@ class ImageMixin:
             width, height = 640, 640 / PICTURE_RATIO
         width = int(width)
         height = int(height)
-        print(f"===> ({width=}, {height=})")
         return {
             "size": (width, height),
             "crop": crop,


### PR DESCRIPTION
This fixes an issue that leads to ~2.6 times too low resolutions for portrait images that have a fixed height or width (but not both). 