### PR TITLE
fix: Use gettext_lazy for model verbose names

### DIFF
--- a/djangocms_frontend/contrib/icon/models.py
+++ b/djangocms_frontend/contrib/icon/models.py
@@ -1,4 +1,4 @@
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 from djangocms_frontend.models import FrontendUIItem
 

--- a/djangocms_frontend/contrib/listgroup/models.py
+++ b/djangocms_frontend/contrib/listgroup/models.py
@@ -1,4 +1,4 @@
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 from ...models import FrontendUIItem
 

--- a/djangocms_frontend/contrib/media/models.py
+++ b/djangocms_frontend/contrib/media/models.py
@@ -1,4 +1,4 @@
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 from djangocms_frontend.models import FrontendUIItem
 

--- a/djangocms_frontend/contrib/tabs/models.py
+++ b/djangocms_frontend/contrib/tabs/models.py
@@ -1,4 +1,4 @@
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 from ...models import FrontendUIItem
 

--- a/djangocms_frontend/contrib/utilities/models.py
+++ b/djangocms_frontend/contrib/utilities/models.py
@@ -1,4 +1,4 @@
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 from ...models import FrontendUIItem
 

--- a/djangocms_frontend/models.py
+++ b/djangocms_frontend/models.py
@@ -3,7 +3,8 @@ from cms.utils.compat import DJANGO_3_0
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 from django.utils.html import conditional_escape, mark_safe
-from django.utils.translation import gettext, gettext_lazy as _
+from django.utils.translation import gettext
+from django.utils.translation import gettext_lazy as _
 
 from djangocms_frontend.fields import TagTypeField
 from djangocms_frontend.settings import FRAMEWORK_PLUGIN_INFO

--- a/djangocms_frontend/models.py
+++ b/djangocms_frontend/models.py
@@ -3,7 +3,7 @@ from cms.utils.compat import DJANGO_3_0
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 from django.utils.html import conditional_escape, mark_safe
-from django.utils.translation import gettext
+from django.utils.translation import gettext, gettext_lazy as _
 
 from djangocms_frontend.fields import TagTypeField
 from djangocms_frontend.settings import FRAMEWORK_PLUGIN_INFO
@@ -43,7 +43,7 @@ class AbstractFrontendUIItem(CMSPlugin):
 
     class Meta:
         abstract = True
-        verbose_name = gettext("UI item")
+        verbose_name = _("UI item")
 
     ui_item = models.CharField(max_length=30)
     tag_type = TagTypeField(blank=True)
@@ -141,4 +141,4 @@ class FrontendUIItem(AbstractFrontendUIItem):
 
     """
     class Meta:
-        verbose_name = gettext("UI item")
+        verbose_name = _("UI item")


### PR DESCRIPTION
Hi,
model field `verbose_names` should use `gettext_lazy`, because it creates migrations based on user language settings.
```
manage.py makemigrations --dry-run
Migrations for 'djangocms_frontend':
  /home/x/lib/python3.9/site-packages/djangocms_frontend/migrations/0002_alter_frontenduiitem_options.py
    - Change Meta options on frontenduiitem
Migrations for 'listgroup':
  /home/x/lib/python3.9/site-packages/djangocms_frontend/contrib/listgroup/migrations/0002_alter_listgroup_options_alter_listgroupitem_options.py
    - Change Meta options on listgroup
    - Change Meta options on listgroupitem
Migrations for 'media':
  /home/x/lib/python3.9/site-packages/djangocms_frontend/contrib/media/migrations/0002_alter_media_options_alter_mediabody_options.py
    - Change Meta options on media
    - Change Meta options on mediabody
Migrations for 'tabs':
  /home/x/lib/python3.9/site-packages/djangocms_frontend/contrib/tabs/migrations/0002_alter_tab_options_alter_tabitem_options.py
    - Change Meta options on tab
    - Change Meta options on tabitem
Migrations for 'utilities':
  /home/x/lib/python3.9/site-packages/djangocms_frontend/contrib/utilities/migrations/0002_alter_heading_options_alter_spacing_options_and_more.py
    - Change Meta options on heading
    - Change Meta options on spacing
    - Change Meta options on tableofcontents
```
