### PR TITLE
fix: setting `DJANGOCMS_FRONTEND_MINIMUM_INPUT_LENGTH` caused a regression when updating opt groups

### DIFF
--- a/djangocms_frontend/__init__.py
+++ b/djangocms_frontend/__init__.py
@@ -19,4 +19,4 @@ Release logic:
 13. Github actions will publish the new package to pypi
 """
 
-__version__ = "1.3.4"
+__version__ = "1.3.3"

--- a/djangocms_frontend/__init__.py
+++ b/djangocms_frontend/__init__.py
@@ -19,4 +19,4 @@ Release logic:
 13. Github actions will publish the new package to pypi
 """
 
-__version__ = "1.3.3"
+__version__ = "1.3.4"

--- a/djangocms_frontend/contrib/link/forms.py
+++ b/djangocms_frontend/contrib/link/forms.py
@@ -109,7 +109,8 @@ class Select2jqWidget(AutocompleteMixin, forms.Select):
 
     def optgroups(self, name, value, attr=None):
         groups = super(forms.Select, self).optgroups(name, value)
-        if not self.is_required:
+        if not self.is_required and groups:
+            # Add an empty entry to allow for an empty value to be preselected
             groups[0][1].insert(0, self.create_option(name, "", "", False, 0))
         return groups
 


### PR DESCRIPTION
#226 