### PR TITLE
feat: Use Django CMS 4.2 capabilities

### DIFF
--- a/djangocms_frontend/contrib/accordion/cms_plugins.py
+++ b/djangocms_frontend/contrib/accordion/cms_plugins.py
@@ -73,6 +73,8 @@ class AccordionItemPlugin(mixin_factory("AccordionItem"), CMSUIPlugin):
     model = models.AccordionItem
     form = forms.AccordionItemForm
     allow_children = True
+    show_plugin_add_form = False
+
     parent_classes = [
         "AccordionPlugin",
     ]

--- a/djangocms_frontend/contrib/grid/cms_plugins.py
+++ b/djangocms_frontend/contrib/grid/cms_plugins.py
@@ -35,6 +35,7 @@ class GridContainerPlugin(
     form = forms.GridContainerForm
     change_form_template = "djangocms_frontend/admin/grid_container.html"
     allow_children = True
+    show_plugin_add_form = False
 
     fieldsets = [
         (
@@ -152,7 +153,7 @@ class GridColumnPlugin(
     # TODO it should allow for the responsive utility class
     # https://getbootstrap.com/docs/5.0/layout/grid/#column-resets
     parent_classes = ["GridRowPlugin"]
-    edit_disabled = True
+    show_plugin_add_form = False
 
     fieldsets = [
         (


### PR DESCRIPTION
* Directly add accordion item
* Directly add columns to rows

## Summary by Sourcery

Enable adding accordion items and columns to rows directly in Django CMS 4.2.

New Features:
- Add accordion items directly.
- Add columns to rows directly.