### PR TITLE
fix: inline editing crashed for plugin template tags

### DIFF
--- a/djangocms_frontend/templatetags/frontend.py
+++ b/djangocms_frontend/templatetags/frontend.py
@@ -268,9 +268,9 @@ class InlineField(CMSEditableObject):
     )
 
     def render_tag(self, context, **kwargs):
-        if context["request"].session.get("inline_editing", True) and isinstance(kwargs["instance"], CMSPlugin):
+        if context["request"].session.get("inline_editing", True) and isinstance(kwargs["instance"], CMSPlugin) and kwargs["instance"].pk:
             # Only allow inline field to be rendered if inline editing is active and the instance is a CMSPlugin
-            # DummyPlugins of the ``plugin`` tag are cannot be edited
+            # DummyPlugins of the ``plugin`` tag are cannot be edited (they have no pk in their model class)
             kwargs["edit_fields"] = kwargs["attribute"]
             return super().render_tag(context, **kwargs)
         else:

--- a/docs/source/how-to/use-frontend-as-component.rst
+++ b/docs/source/how-to/use-frontend-as-component.rst
@@ -98,3 +98,32 @@ use the ``{% plugin %}`` template tag with each plugin.
     Currently, ``{% placeholder %}`` template tags are not supported inside
     a ``{% plugin %}`` tag. This is because the ``{% plugin %}`` tag does
     preprocess the content and placeholders are not recognized by django CMS.
+
+Multi-line tags
+===============
+
+Multi-line tags are not supported in Django templates. For components with many
+parameters this can lead to long lines of code. To make the code more readable
+you can use the following patch (to be executed, for example during your project's
+``AppConfig.ready()`` method):
+
+.. code-block:: python
+
+    import re
+    from django.template import base
+
+    base.tag_re = re.compile(base.tag_re.pattern, re.DOTALL)
+
+This will patch the Django template engine **for all templates rendered by it
+within your project.** It will however allow templates like this:
+
+.. code-block:: django
+
+    {% plugin "card"
+        card_alignment="center"
+        card_outline="info"
+        card_text_color="primary"
+        card_full_height=True %}
+        ...
+    {% endplugin %}
+


### PR DESCRIPTION
`{% plugin %}` template tags cannot offer inline editing and hence need to disable it.