### PR TITLE
Update bootstrap4_migration.py

### DIFF
--- a/djangocms_frontend/management/bootstrap4_migration.py
+++ b/djangocms_frontend/management/bootstrap4_migration.py
@@ -454,9 +454,11 @@ def g001_col_text_alignment(obj, new_obj):
     if "text-center" in classes:
         classes.remove("text-center")
         new_obj.config["text_alignment"] = "center"
-    if "text-right" in classes or "text-end" in classes:
-        classes.remove("text-right")
+    if "text-end" in classes:
         classes.remove("text-end")
+        new_obj.config["text_alignment"] = "end"
+    if "text-right" in classes:
+        classes.remove("text-right")
         new_obj.config["text_alignment"] = "end"
     if classes:
         new_obj.config["attributes"]["class"] = " ".join(classes)


### PR DESCRIPTION
This helped to be able to migrate from djangocms-bootstrap4

## Summary by Sourcery

Update migration logic for text alignment classes in bootstrap4 migration script

Bug Fixes:
- Fix migration of 'text-right' and 'text-end' classes to ensure correct text alignment configuration

Enhancements:
- Improve handling of text alignment classes during migration from djangocms-bootstrap4