### PR TITLE
fix: Force rediscovery of inline fields

### DIFF
--- a/djangocms_frontend/component_pool.py
+++ b/djangocms_frontend/component_pool.py
@@ -148,7 +148,7 @@ def setup():
         if apps.is_installed("djangocms_text"):
             # Hack - update inline editable fields in case djangocms_text is installed
             # BEFORE djangocms_frontend in INSTALLED_APPS:
-            # Need to initialize inline fields again to reflect inline fields in of just discovered components
+            # Need to initialize inline fields again to reflect inline fields of the just discovered components
             from djangocms_text.apps import discover_inline_editable_models
 
             text_config = apps.get_app_config("djangocms_text")

--- a/djangocms_frontend/component_pool.py
+++ b/djangocms_frontend/component_pool.py
@@ -147,11 +147,9 @@ def setup():
 
         if apps.is_installed("djangocms_text"):
             # Hack - update inline editable fields in case djangocms_text is installed
-            # BEFORE djangocms_frontend in INSTALLED_APPS
-            text_config = apps.get_app_config("djangocms_text")
-            if text_config.inline_models:
-                # Already initialized? Need to initialize again
-                # to reflect inline fields in of just discovered components
-                from djangocms_text.apps import discover_inline_editable_models
+            # BEFORE djangocms_frontend in INSTALLED_APPS:
+            # Need to initialize inline fields again to reflect inline fields in of just discovered components
+            from djangocms_text.apps import discover_inline_editable_models
 
-                text_config.inline_models = discover_inline_editable_models()
+            text_config = apps.get_app_config("djangocms_text")
+            text_config.inline_models = discover_inline_editable_models()


### PR DESCRIPTION
If djangocms-text is initialized before djangocms-frontend AND no other inline fields are declared, inline fields of template components are not discovered.

## Summary by Sourcery

Bug Fixes:
- Ensure inline fields of template components are discovered correctly when djangocms-text is loaded before djangocms-frontend