### PR TITLE
chore: Prepare release 2.1.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,13 +2,23 @@
 Changelog
 =========
 
+2.1.2 (2025-05-05)
+==================
+
+* fix: Force rediscovery of inline fields by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/272
+* fix: Bootstrap4 migration failed in some cases by @milonline-eu in https://github.com/django-cms/djangocms-frontend/pull/270
+
+**New Contributors**
+
+* @milonline-eu made their first contribution in https://github.com/django-cms/djangocms-frontend/pull/270
+
+
 2.1.1 (2025-03-29)
 ==================
 
 * feat: add `instance.get_classes` for template components by @fsbraun
   in https://github.com/django-cms/djangocms-frontend/pull/268
 * docs: Reference example template components
-
 
 2.1.0 (2025-03-26)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 ==================
 
 * fix: Force rediscovery of inline fields by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/272
-* fix: Bootstrap4 migration failed in some cases by @milonline-eu in https://github.com/django-cms/djangocms-frontend/pull/270
+* fix: Bootstrap 4 migration failed in some cases by @milonline-eu in https://github.com/django-cms/djangocms-frontend/pull/270
 
 **New Contributors**
 

--- a/djangocms_frontend/__init__.py
+++ b/djangocms_frontend/__init__.py
@@ -19,4 +19,4 @@ Release logic:
 13. Github actions will publish the new package to pypi
 """
 
-__version__ = "2.1.1"
+__version__ = "2.1.2"

--- a/djangocms_frontend/component_pool.py
+++ b/djangocms_frontend/component_pool.py
@@ -148,7 +148,7 @@ def setup():
         if apps.is_installed("djangocms_text"):
             # Hack - update inline editable fields in case djangocms_text is installed
             # BEFORE djangocms_frontend in INSTALLED_APPS:
-            # Need to initialize inline fields again to reflect inline fields in of just discovered components
+            # Need to initialize inline fields again to reflect inline fields of the just discovered components
             from djangocms_text.apps import discover_inline_editable_models
 
             text_config = apps.get_app_config("djangocms_text")

--- a/djangocms_frontend/component_pool.py
+++ b/djangocms_frontend/component_pool.py
@@ -147,11 +147,9 @@ def setup():
 
         if apps.is_installed("djangocms_text"):
             # Hack - update inline editable fields in case djangocms_text is installed
-            # BEFORE djangocms_frontend in INSTALLED_APPS
-            text_config = apps.get_app_config("djangocms_text")
-            if text_config.inline_models:
-                # Already initialized? Need to initialize again
-                # to reflect inline fields in of just discovered components
-                from djangocms_text.apps import discover_inline_editable_models
+            # BEFORE djangocms_frontend in INSTALLED_APPS:
+            # Need to initialize inline fields again to reflect inline fields in of just discovered components
+            from djangocms_text.apps import discover_inline_editable_models
 
-                text_config.inline_models = discover_inline_editable_models()
+            text_config = apps.get_app_config("djangocms_text")
+            text_config.inline_models = discover_inline_editable_models()


### PR DESCRIPTION
## Summary by Sourcery

Prepare release 2.1.2 by updating version number and refactoring djangocms_text initialization logic

Enhancements:
- Simplify initialization logic for djangocms_text inline editable models

Chores:
- Bump package version from 2.1.1 to 2.1.2