### PR TITLE
feat: simpler component configuration 

### DIFF
--- a/djangocms_frontend/cms_plugins.py
+++ b/djangocms_frontend/cms_plugins.py
@@ -1,4 +1,5 @@
 from cms.plugin_pool import plugin_pool
+from django.core.exceptions import ImproperlyConfigured
 
 from .ui_plugin_base import CMSUIPluginBase
 
@@ -11,7 +12,7 @@ def update_plugin_pool():
     from .component_pool import components
 
     # Loop through the values in the components' registry
-    for _, plugin, slot_plugins in components._registry.values():
+    for key, (_, plugin, slot_plugins) in components._registry.items():
         if plugin.__name__ not in plugin_pool.plugins:
             # Add the plugin to the global namespace
             globals()[plugin.__name__] = plugin
@@ -24,3 +25,8 @@ def update_plugin_pool():
                 globals()[slot_plugin.__name__] = slot_plugin
                 # Register the slot plugin with the plugin pool
                 plugin_pool.register_plugin(slot_plugin)
+        else:
+            raise ImproperlyConfigured(
+                f"Cannot register frontend component {key} since a plugin {plugin.__name__} "
+                f"is already registered by {plugin_pool.plugins[plugin.__name__].__module__}."
+            )

--- a/djangocms_frontend/component_base.py
+++ b/djangocms_frontend/component_base.py
@@ -174,7 +174,7 @@ class CMSFrontendComponent(forms.Form):
                         if hasattr(cls, "get_render_template")
                         else {}
                     ),
-                    "__module__": cls.__module__,
+                    "__module__": "djangocms_frontend.cms_plugins",
                 },
             )
         return cls._plugin

--- a/djangocms_frontend/plugin_tag.py
+++ b/djangocms_frontend/plugin_tag.py
@@ -25,11 +25,6 @@ IGNORED_FIELDS = (
     "ui_item",
 )
 
-allowed_plugin_types = tuple(
-    getattr(importlib.import_module(cls.rsplit(".", 1)[0]), cls.rsplit(".", 1)[-1]) if isinstance(cls, str) else cls
-    for cls in getattr(settings, "CMS_COMPONENT_PLUGINS", [])
-)
-
 
 def _get_plugindefaults(instance):
     defaults = {
@@ -65,7 +60,20 @@ def patch_template(template):
     return copied_template if patch else template
 
 
+def get_plugin_class(settings_string: str | type) -> type:
+    """Get the plugin class from the settings string or import it if it's a dotted path."""
+    if isinstance(settings_string, str):
+        if "." in settings_string:
+            # import the class if a dotted oath is given
+            return importlib.import_module(*settings_string.rsplit(".", 1))
+        # Get the plugin class from the plugin pool by its name
+        return plugin_pool.get_plugin(settings_string)
+    return settings_string
+
+
 def setup():
+    allowed_plugin_types = tuple(get_plugin_class(cls) for cls in getattr(settings, "CMS_COMPONENT_PLUGINS", []))
+
     for plugin in plugin_pool.get_all_plugins():
         if not issubclass(plugin, allowed_plugin_types):
             continue

--- a/djangocms_frontend/plugin_tag.py
+++ b/djangocms_frontend/plugin_tag.py
@@ -65,7 +65,8 @@ def get_plugin_class(settings_string: str | type) -> type:
     if isinstance(settings_string, str):
         if "." in settings_string:
             # import the class if a dotted oath is given
-            return importlib.import_module(*settings_string.rsplit(".", 1))
+            module_name, class_name = settings_string.rsplit(".", 1)
+            return getattr(importlib.import_module(module_name), class_name, None)
         # Get the plugin class from the plugin pool by its name
         return plugin_pool.get_plugin(settings_string)
     return settings_string

--- a/docs/source/how-to/use-frontend-as-component.rst
+++ b/docs/source/how-to/use-frontend-as-component.rst
@@ -22,8 +22,9 @@ repetition.
 
     To make plugins available as components, ensure that the
     ``CMS_COMPONENT_PLUGINS`` setting in your project's ``settings.py``
-    includes the necessary plugin classes and their subclasses. This setting
-    allows you to specify which plugins can be used directly in templates
+    is a list that includes the necessary plugin names or dotted path to
+    a plugin parent class . Only plugins named in the listing or their
+    child classes can be used directly in templates
     without creating database entries.
 
     * To include all ``djangocms-frontend`` plugins, use


### PR DESCRIPTION
To simplify the configuration used for component plug-ins, `CMS_COMPONENT_PLUGINS` now accepts entries with a plug-in name in addition to a dotted path. It will look up the plug-in on the plug-in pool.