### PR TITLE
fix: AttributeError CMSPlugin (EditorNotePlugin) object has no attribute config

### DIFF
--- a/djangocms_frontend/ui_plugin_base.py
+++ b/djangocms_frontend/ui_plugin_base.py
@@ -3,6 +3,7 @@ from cms.plugin_base import CMSPluginBase
 from django.utils.encoding import force_str
 
 from djangocms_frontend.helpers import get_related
+from djangocms_frontend.models import AbstractFrontendUIItem
 
 try:
     from cms.admin.placeholderadmin import PlaceholderAdmin
@@ -30,12 +31,13 @@ class CMSUIPluginBase(FrontendEditableAdminMixin, CMSPluginBase):
         return force_str(super().__str__())
 
     def render(self, context, instance, placeholder):
-        for key, value in instance.config.items():
-            if isinstance(value, dict) and set(value.keys()) == {"pk", "model"}:
-                if key not in instance.__dir__():  # hasattr would return the value in the config dict
-                    setattr(instance.__class__, key, get_related(key))
-        if "instance" not in instance.config and isinstance(instance.config, dict):
-            context.update(instance.config)
+        if isinstance(instance, AbstractFrontendUIItem):
+            for key, value in instance.config.items():
+                if isinstance(value, dict) and set(value.keys()) == {"pk", "model"}:
+                    if key not in instance.__dir__():  # hasattr would return the value in the config dict
+                        setattr(instance.__class__, key, get_related(key))
+            if "instance" not in instance.config and isinstance(instance.config, dict):
+                context.update(instance.config)
         return super().render(context, instance, placeholder)
 
     if not hasattr(PlaceholderAdmin, "edit_field"):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -119,6 +119,8 @@ CMS_TEMPLATES = (("page.html", "Page"),)
 
 SITE_ID = 1
 
+STATIC_URL = "/static/"
+
 ROOT_URLCONF = "tests.urls"
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/tests/utilities/test_plugins.py
+++ b/tests/utilities/test_plugins.py
@@ -164,6 +164,5 @@ class UtilitiesPluginTestCase(TestFixture, CMSTestCase):
 
         with self.login_user_context(self.superuser):
             response = self.client.get(endpoint)
-        print(response.content)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'My private note')


### PR DESCRIPTION
Plugin `EditorNotePlugin` does not inherit form `AttributesMixin`. This raises `AttributeError` in function `render` where is the code `instance.config.items()`. There could be more such plugins, so it is advisable to insert a condition in the `render` function. It would also be inappropriate to add `AttributesMixin` to a class when the class does not need it.

The `render` function is missing a test for the `EditorNotePlugin` plugin, otherwise the bug would have been found already. Unfortunately, I am currently unable to complete the test due to time constraints.

## Summary by Sourcery

Bug Fixes:
- Check for instance.config presence before iterating its items in render() to avoid errors for plugins without config attributes