### PR TITLE
chore: Add test for editor note plugin

### DIFF
--- a/djangocms_frontend/templatetags/frontend.py
+++ b/djangocms_frontend/templatetags/frontend.py
@@ -39,7 +39,7 @@ def is_inline_editing_active(context: template.Context) -> bool:
 
 
 def update_component_properties(context: template.Context, key: str, value: typing.Any, append: bool = False) -> None:
-    """"Adds or appends the value to the property "key" of a component during delcaration"""
+    """ "Adds or appends the value to the property "key" of a component during delcaration"""
     args, kwargs = context["_cms_components"]["cms_component"][0]
     if append:
         # Populate slots with plugin_type and verbose_name
@@ -318,11 +318,7 @@ class InlineField(CMSEditableObject):
 
         if is_registering_component(context) and attribute:
             update_component_properties(context, "frontend_editable_fields", attribute, append=True)
-        elif (
-            is_inline_editing_active(context)
-            and isinstance(instance, CMSPlugin)
-            and instance.pk
-        ):
+        elif is_inline_editing_active(context) and isinstance(instance, CMSPlugin) and instance.pk:
             # Only allow inline field to be rendered if inline editing is active and the instance is a CMSPlugin
             # DummyPlugins of the ``plugin`` tag are cannot be edited (they have no pk in their model class)
             kwargs["edit_fields"] = attribute

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -22,7 +22,6 @@ class TestFixture:
             title="content",
             template="page.html",
         )
-        self.publish(self.page, self.language)
         self.placeholder = self.get_placeholders(self.page).get(slot="content")
         self.request_url = (
             self.page.get_absolute_url(self.language) + "?toolbar_off=true"
@@ -80,7 +79,9 @@ class TestFixture:
             return create_page(title=title, **kwargs)
 
         def get_placeholders(self, page):
-            return page.get_placeholders(self.language)
+            from cms.models import Placeholder, PageContent
+            page_content = PageContent.admin_manager.latest_content().get(language=self.language, page=self.page)
+            return Placeholder.objects.get_for_obj(page_content)
 
         try:
             import djangocms_url_manager as __just_testing__

--- a/tests/utilities/test_plugins.py
+++ b/tests/utilities/test_plugins.py
@@ -1,8 +1,13 @@
+from unittest import skipIf
+from cms import __version__ as cms_version
 from cms.api import add_plugin
 from cms.test_utils.testcases import CMSTestCase
 from cms.utils.urlutils import admin_reverse
 
+from djangocms_text.cms_plugins import TextPlugin
+
 from djangocms_frontend.contrib.utilities.cms_plugins import (
+    EditorNotePlugin,
     HeadingPlugin,
     SpacingPlugin,
     TOCPlugin,
@@ -117,3 +122,48 @@ class UtilitiesPluginTestCase(TestFixture, CMSTestCase):
         heading.refresh_from_db()
         self.assertEqual(heading.heading, "My new heading")  # New data
         self.assertEqual(heading.heading_id, "id1")  # Other fields unchanged
+
+    def test_editor_note(self):
+        editor_note = add_plugin(
+            placeholder=self.placeholder,
+            plugin_type=EditorNotePlugin.__name__,
+            language=self.language,
+        )
+        add_plugin(
+            placeholder=self.placeholder,
+            plugin_type=TextPlugin.__name__,
+            language=self.language,
+            target=editor_note,
+            body="<p>My private note</p>",
+        )
+        self.publish(self.page, self.language)
+
+        with self.login_user_context(self.superuser):
+            response = self.client.get(self.request_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'My private note')
+
+    @skipIf(cms_version < "4", "django CMS 4+ required")
+    def test_editor_note_with_cms4(self):
+        from cms.toolbar.utils import get_object_edit_url
+
+        editor_note = add_plugin(
+            placeholder=self.placeholder,
+            plugin_type=EditorNotePlugin.__name__,
+            language=self.language,
+        )
+        add_plugin(
+            placeholder=self.placeholder,
+            plugin_type=TextPlugin.__name__,
+            language=self.language,
+            target=editor_note,
+            body="<p>My private note</p>",
+        )
+
+        endpoint = get_object_edit_url(self.page.get_admin_content("en"))
+
+        with self.login_user_context(self.superuser):
+            response = self.client.get(endpoint)
+        print(response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'My private note')


### PR DESCRIPTION
## Summary by Sourcery

Add tests for the EditorNotePlugin and adjust test fixtures and template tags to support proper placeholder retrieval and inline editing behavior.

Enhancements:
- Simplify the inline editing condition in render_tag to a single-line check.
- Correct the docstring formatting in update_component_properties.

Tests:
- Add tests to verify that editor notes are hidden on public pages and visible in the CMS4 editing interface.
- Update test fixtures by removing redundant page publish and refactor get_placeholders to use PageContent.latest_content and Placeholder.objects.get_for_obj.