### PR TITLE
chore: fix column per row not been saved and added tests

### DIFF
--- a/djangocms_frontend/contrib/grid/forms.py
+++ b/djangocms_frontend/contrib/grid/forms.py
@@ -127,11 +127,11 @@ for size in settings.DEVICE_SIZES:
     )
 
 
-GridRowBaseForm.Meta.entangled_fields["config"] += extra_fields_column.keys()
+GridRowBaseForm._meta.entangled_fields["config"] += extra_fields_column.keys()
 
 
 GridRowForm = type(
-    "GridRowBaseForm",
+    "GridRowForm",
     (GridRowBaseForm,),
     copy(extra_fields_column),
 )
@@ -226,10 +226,10 @@ for size in settings.DEVICE_SIZES:
         widget=forms.HiddenInput() if "{size}_me" in getattr(settings, "EXCL_COL_PROP", ()) else forms.CheckboxInput(),
     )
 
+GridColumnBaseForm._meta.entangled_fields["config"] += extra_fields_column.keys()
+
 GridColumnForm = type(
     "GridColumnForm",
     (GridColumnBaseForm,),
     copy(extra_fields_column),
 )
-
-GridColumnForm._meta.entangled_fields["config"] += extra_fields_column.keys()

--- a/tests/grid/test_forms.py
+++ b/tests/grid/test_forms.py
@@ -1,0 +1,44 @@
+from django.test import TestCase
+
+from djangocms_frontend.contrib.grid.forms import (
+    GridColumnForm,
+    GridRowForm,
+    GridContainerForm)
+
+
+class GridFormTestCase(TestCase):
+    def test_grid_container_form(self):
+        form = GridContainerForm(data={
+            "container_type": "container",
+            "tag_type": "div",
+            "margin_devices": ['xl'],
+            "padding_devices": ['xs'],
+        })
+        self.assertTrue(form.is_valid())
+        self.assertIn("container_type", form.instance.config)
+        self.assertEqual(form.instance.container_type, "container")
+
+    def test_grid_row_form(self):
+        form = GridRowForm(data={
+            "margin_devices": ['xl'],
+            "padding_devices": ['xs'],
+            "row_cols_xs": 5,
+        })
+        self.assertTrue(form.is_valid())
+        self.assertIn("row_cols_xs", form.instance.config)
+        self.assertIn("row_cols_xxl", form.instance.config)
+        self.assertEqual(form.instance.row_cols_xs, 5)
+
+    def test_grid_column_form(self):
+        form = GridColumnForm(data={
+            "margin_devices": ['xl'],
+            "padding_devices": ['xs'],
+            "text_alignment": "",
+            "xs_col": "6",
+            "xl_offset": "",
+
+        })
+
+        self.assertTrue(form.is_valid())
+        self.assertIn("md_me", form.instance.config)
+        self.assertEqual(form.instance.xs_col, 6)


### PR DESCRIPTION
- Fixes #289 
- Added test for DeviceChoiceField
- Added tests for grid forms

## Summary by Sourcery

Fix saving of per-row column settings by correcting entangled_fields metadata and form naming in grid forms, and add unit tests for device choice fields and grid container/row/column forms

Bug Fixes:
- Use _meta instead of Meta to register extra config fields on GridRowForm and GridColumnForm
- Rename generated grid row form type to "GridRowForm" for consistency
- Persist extra_fields_column keys so column-per-row settings are saved correctly

Tests:
- Add tests for DeviceChoiceField and OptionalDeviceChoiceField behavior
- Add tests for GridContainerForm, GridRowForm, and GridColumnForm to verify config persistence and validation