### PR TITLE
chore: Use split button for menu dropdown

### DIFF
--- a/djangocms_frontend/templates/bootstrap5/menu.html
+++ b/djangocms_frontend/templates/bootstrap5/menu.html
@@ -1,13 +1,12 @@
 {% load i18n menu_tags cache %}{% spaceless %}
     {% for child in children %}
-        <li class="nav-item text-center {% if child.ancestor %}ancestor{% endif %}{% if child.children %} dropdown{% endif %}">
-            {% if child.children %}<a class="nav-link dropdown-toggle{% if child.selected %} active{% endif %}" role="button" data-bs-toggle="dropdown" data-request="{{ request.path }}" href="{{ child.get_absolute_url }}" id="menu-{{ child.id|safe }}">{{ child.get_menu_title }}</a>
-                <div class="dropdown-menu" aria-labelledby="menu-{{ child.ancestor.id|safe }}">
-                    {% show_menu from_level to_level extra_inactive extra_active "bootstrap5/dropdown.html" "" "" child %}
-                </div>
-            {% else %}
-                <a class="nav-link{% if child.selected %} active{% endif %}" href="{{ child.get_absolute_url }}"><span>{{ child.get_menu_title }}</span></a>
-            {% endif %}
-        </li>
+      <li class="btn-group {% if child.ancestor %}ancestor{% endif %}{% if child.children %} dropdown{% endif %}">
+	<a class="nav-link{% if child.selected %} active{% endif %}" data-request="{{ request.path }}" id="menu-{{ child.id|safe }}" href="{{ child.get_absolute_url }}">{{ child.get_menu_title }}</a>
+        {% if child.children %}<button class="nav-link btn-secondary btn-sm dropdown-toggle" style="padding-left: 0;" data-bs-toggle="dropdown" aria-expanded="false" data-bs-reference="parent"></button>
+	<div class="dropdown-menu" aria-labelledby="menu-{{ child.ancestor.id|safe }}">
+          {% show_menu from_level to_level extra_inactive extra_active "bootstrap5/dropdown.html" "" "" child %}
+        </div>
+	{% endif %}
+      </li>
     {% endfor %}
 {% endspaceless %}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -73,5 +73,5 @@ function task(id, extra) {
 gulp.task('sass', task('sass'));
 
 gulp.task('watch', function () {
-    gulp.watch(PROJECT_PATTERNS.sass, ['sass']);
+    gulp.watch(PROJECT_PATTERNS.sass, gulp.series('sass'));
 });


### PR DESCRIPTION
- Update gulpfile.js to use v4 style
- Use split button for menu dropdown