### PR TITLE
fix: typo in German translation ("Splaten" → "Spalten")

### DIFF
--- a/djangocms_frontend/locale/de/LC_MESSAGES/django.po
+++ b/djangocms_frontend/locale/de/LC_MESSAGES/django.po
@@ -417,7 +417,7 @@ msgstr "Inhalts-Ausrichtung"
 #: contrib/card/templates/djangocms_frontend/admin/card_layout.html:14
 #: contrib/grid/templates/djangocms_frontend/admin/grid_row.html:13
 msgid "Colums per row"
-msgstr "Splaten pro Zeile"
+msgstr "Spalten pro Zeile"
 
 #: contrib/carousel/cms_plugins.py:25 contrib/carousel/models.py:20
 msgid "Carousel"


### PR DESCRIPTION
The German translation in djangocms_frontend/locale/de/LC_MESSAGES/django.po contained a minor spelling error in the label for “Columns per row”. This commit corrects 'Splaten pro Zeile' to 'Spalten pro Zeile' for accuracy and consistency.

## Summary by Sourcery

Documentation:
- Correct 'Splaten pro Zeile' to 'Spalten pro Zeile' in the German locale file