### PR TITLE
fix: uuid is not a valid selector.

### DIFF
--- a/djangocms_frontend/contrib/collapse/templates/djangocms_frontend/bootstrap5/collapse-container.html
+++ b/djangocms_frontend/contrib/collapse/templates/djangocms_frontend/bootstrap5/collapse-container.html
@@ -2,7 +2,7 @@
 <{{ instance.tag_type }}{{ instance.get_attributes }}
     id="{{ instance.container_identifier }}"
     role="tabpanel"
-    data-bs-parent="#{{ parent.uuid }}"
+    data-bs-parent="#collapse-{{ parent.uuid }}"
     aria-labelledby="trigger-{{ instance.container_identifier }}">
     {% for plugin in instance.child_plugin_instances %}
         {% with forloop as parentloop %}{% render_plugin plugin %}{% endwith %}

--- a/djangocms_frontend/contrib/collapse/templates/djangocms_frontend/bootstrap5/collapse.html
+++ b/djangocms_frontend/contrib/collapse/templates/djangocms_frontend/bootstrap5/collapse.html
@@ -1,6 +1,6 @@
 {% load cms_tags frontend %}
 <{{ instance.tag_type }}{{ instance.get_attributes }}
-id="{{ instance.uuid }}"
+id="collapse-{{ instance.uuid }}"
 data-bs-children="{{ instance.collapse_siblings }}"
 role="tablist"
 >


### PR DESCRIPTION
The [uuid.uuid4()](https://github.com/django-cms/djangocms-frontend/blob/2.0.0/djangocms_frontend/models.py#L51) function generates a random number in the format of 32 hexadecimal digits divided into five groups separated by hyphens. Such a value then starts with a character in the range `0-9a-f`.
However, an identifier `html.id` starting with a number is not valid for some JavaScript functions. The function then ends with a SyntaxError.

```html
<div id="81143815-0b4c-4805-85c6-61e96db1259a">...</div>
```
```javascript
document.querySelector("#81143815-0b4c-4805-85c6-61e96db1259a")

"[Line 1] Uncaught SyntaxError: Failed to execute 'querySelector' on 'Document':
  '#81143815-0b4c-4805-85c6-61e96db1259a' is not a valid selector."
```

It was reflected in the Collapse plugin in the [findOne](https://github.com/twbs/bootstrap/blob/v5.0.2/js/src/dom/selector-engine.js#L22) and [next](https://github.com/twbs/bootstrap/blob/v5.3.8/js/src/dom/selector-engine.js#L79) functions.

The same problem could occur with the Accordion plugin, but it is handled correctly there with the [parent](https://github.com/django-cms/djangocms-frontend/blob/2.0.0/djangocms_frontend/contrib/accordion/templates/djangocms_frontend/bootstrap5/accordion.html#L2), [heading](https://github.com/django-cms/djangocms-frontend/blob/2.0.0/djangocms_frontend/contrib/accordion/templates/djangocms_frontend/bootstrap5/accordion_item.html#L5) and [item](https://github.com/django-cms/djangocms-frontend/blob/2.0.0/djangocms_frontend/contrib/accordion/templates/djangocms_frontend/bootstrap5/accordion_item.html#L13) prefix.

### Note

Using randomly generated values ​​for the `html.id` attribute is inappropriate because when [comparing versions](https://github.com/django-cms/djangocms-versioning), such elements never match and the comparison thus shows changes that never occurred. A different way of generating the id should be devised so that it does not show unwanted differences when comparing versions.

## Summary by Sourcery

Bug Fixes:
- Ensure collapse container parent selectors use an ID prefixed with 'collapse-' so querySelector and Bootstrap’s selector engine can handle UUID-based IDs starting with digits.