### PR TITLE
feat: Add the set_html_id template tag to resolve the random html.id attribute.

### DIFF
--- a/djangocms_frontend/contrib/accordion/templates/djangocms_frontend/bootstrap5/accordion.html
+++ b/djangocms_frontend/contrib/accordion/templates/djangocms_frontend/bootstrap5/accordion.html
@@ -1,5 +1,5 @@
 {% load cms_tags frontend %}
-<{{ instance.tag_type }}{{ instance.get_attributes }} id="parent-{{ instance.uuid }}">
+<{{ instance.tag_type }}{{ instance.get_attributes }} {% set_html_id instance as html_id %}id="parent-{{ html_id }}">
     {% for plugin in instance.child_plugin_instances %}
         {% with parentloop=forloop parent=instance %}{% render_plugin plugin %}{% endwith %}
     {% empty %}{% user_message _("Add accordion items here") %}

--- a/djangocms_frontend/contrib/accordion/templates/djangocms_frontend/bootstrap5/accordion_item.html
+++ b/djangocms_frontend/contrib/accordion/templates/djangocms_frontend/bootstrap5/accordion_item.html
@@ -1,16 +1,16 @@
 {% load cms_tags frontend %}
 {% spaceless %}
-    <div class="accordion-item">
+    <div class="accordion-item">{% set_html_id instance as html_id %}
         <{{ parent.accordion_header_type|default:"h2" }} class="accordion-header"
-        id="heading-{{ instance.uuid }}"><button
+            id="heading-{{ instance.html_id }}"><button
             class="accordion-button{% if not instance.accordion_item_open %} collapsed{% endif %} {{ instance.font_size }}"
             type="button"
             data-bs-toggle="collapse"
-            data-bs-target="#item-{{ instance.uuid }}"
+            data-bs-target="#item-{{ instance.html_id }}"
             aria-expanded="{{ instance.accordion_item_open|lower }}"
-            aria-controls="item-{{ instance.uuid }}">{% inline_field instance "accordion_item_header" %}</button>
+            aria-controls="item-{{ instance.html_id }}">{% inline_field instance "accordion_item_header" %}</button>
     </{{ parent.accordion_header_type|default:"h2" }}>
-    <{{ instance.tag_type }}{{ instance.get_attributes }} id="item-{{ instance.uuid }}" aria-labelledby="heading-{{ instance.uuid }}" data-bs-parent="#parent-{{ parent.uuid }}">
+    <{{ instance.tag_type }}{{ instance.get_attributes }} id="item-{{ instance.html_id }}" aria-labelledby="heading-{{ instance.html_id }}" data-bs-parent="#parent-{{ parent.html_id }}">
     <div class="accordion-body">{% endspaceless %}
         {% with parent=instance %}
             {% for plugin in instance.child_plugin_instances %}

--- a/djangocms_frontend/contrib/collapse/templates/djangocms_frontend/bootstrap5/collapse-container.html
+++ b/djangocms_frontend/contrib/collapse/templates/djangocms_frontend/bootstrap5/collapse-container.html
@@ -2,7 +2,7 @@
 <{{ instance.tag_type }}{{ instance.get_attributes }}
     id="{{ instance.container_identifier }}"
     role="tabpanel"
-    data-bs-parent="#collapse-{{ parent.uuid }}"
+    data-bs-parent="#collapse-{{ parent.html_id }}"
     aria-labelledby="trigger-{{ instance.container_identifier }}">
     {% for plugin in instance.child_plugin_instances %}
         {% with forloop as parentloop %}{% render_plugin plugin %}{% endwith %}

--- a/djangocms_frontend/contrib/collapse/templates/djangocms_frontend/bootstrap5/collapse.html
+++ b/djangocms_frontend/contrib/collapse/templates/djangocms_frontend/bootstrap5/collapse.html
@@ -1,6 +1,6 @@
 {% load cms_tags frontend %}
 <{{ instance.tag_type }}{{ instance.get_attributes }}
-id="collapse-{{ instance.uuid }}"
+{% set_html_id instance as html_id %}id="collapse-{{ html_id }}"
 data-bs-children="{{ instance.collapse_siblings }}"
 role="tablist"
 >

--- a/djangocms_frontend/models.py
+++ b/djangocms_frontend/models.py
@@ -1,5 +1,3 @@
-import uuid
-
 from cms.models import CMSPlugin
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
@@ -48,7 +46,7 @@ class AbstractFrontendUIItem(CMSPlugin):
 
     def __init__(self, *args, **kwargs):
         self._additional_classes = []
-        self.uuid = str(uuid.uuid4())
+        self.html_id = None  # HTML id attribute will be set in template tag set_html_id.
         super().__init__(*args, **kwargs)
 
     def __getattr__(self, item):


### PR DESCRIPTION
# Proposal for a solution for a unique and non-random html id attribute

Generating a random uuid is not suitable for version comparison. It is better to define the attribute so that it is the same every time.

The id attribute is set only when rendering HTML tags, according to the order of the tag in the DOM document. This maintains its consistency with respect to its position in the document.

## Summary by Sourcery

Introduce a deterministic HTML id mechanism for frontend UI items and update Bootstrap 5 accordion and collapse templates to use it instead of per-instance UUIDs.

New Features:
- Add a set_html_id template tag that assigns stable HTML id attributes to FrontendUIItem instances based on their render order.

Enhancements:
- Replace random UUID-based ids with template-assigned html_id values in accordion and collapse templates to ensure consistent, comparable DOM ids.