### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
       - name: Cache dependencies
-        uses: actions/cache@v5.0.1
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('docs/requirements.in') }}
@@ -44,7 +44,7 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
       - name: Cache dependencies
-        uses: actions/cache@v5.0.1
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('docs/requirements.in') }}


### PR DESCRIPTION
## Summary

Updates GitHub Actions to their latest versions based on https://simonw.github.io/actions-latest/versions.txt

### Changes

- `actions/cache@v5.0.1` → `actions/cache@v5` in `docs.yml`

### Already up-to-date

The following actions were already at their latest major versions:
- `actions/checkout@v6` ✅
- `actions/setup-python@v6` ✅
- `codecov/codecov-action@v5` ✅
- `amannn/action-semantic-pull-request@v6` ✅

## Summary by Sourcery

CI:
- Relax version pinning for actions/cache in the documentation build workflow to track the v5 major tag.