### PR TITLE
fix(frontend): fail gracefully when django-filer is missing

### DIFF
--- a/djangocms_frontend/contrib/carousel/forms.py
+++ b/djangocms_frontend/contrib/carousel/forms.py
@@ -4,8 +4,7 @@ try:
     import filer
 except ImportError:
     raise ImproperlyConfigured(
-        "Carousel plugin requires django-filer. "
-        "Install it using: pip install djangocms-frontend[filer]"
+        "Carousel plugin requires django-filer. Install it using: pip install djangocms-frontend[filer]"
     )
 
 from django import forms

--- a/djangocms_frontend/contrib/carousel/forms.py
+++ b/djangocms_frontend/contrib/carousel/forms.py
@@ -1,3 +1,13 @@
+from django.core.exceptions import ImproperlyConfigured
+
+try:
+    import filer
+except ImportError:
+    raise ImproperlyConfigured(
+        "Carousel plugin requires django-filer. "
+        "Install it using: pip install djangocms-frontend[filer]"
+    )
+
 from django import forms
 from django.db.models.fields.related import ManyToOneRel
 from django.utils.translation import gettext_lazy as _

--- a/djangocms_frontend/contrib/image/fields.py
+++ b/djangocms_frontend/contrib/image/fields.py
@@ -1,3 +1,13 @@
+from django.core.exceptions import ImproperlyConfigured
+
+try:
+    import filer
+except ImportError:
+    raise ImproperlyConfigured(
+        "Image fields require django-filer. "
+        "Install it using: pip install djangocms-frontend[filer]"
+    )
+
 from django.db.models import ManyToOneRel
 from filer.fields.image import AdminImageFormField, FilerImageField
 from filer.models import Image

--- a/djangocms_frontend/contrib/image/fields.py
+++ b/djangocms_frontend/contrib/image/fields.py
@@ -4,8 +4,7 @@ try:
     import filer
 except ImportError:
     raise ImproperlyConfigured(
-        "Image fields require django-filer. "
-        "Install it using: pip install djangocms-frontend[filer]"
+        "Image fields require django-filer. Install it using: pip install djangocms-frontend[filer]"
     )
 
 from django.db.models import ManyToOneRel

--- a/djangocms_frontend/contrib/image/forms.py
+++ b/djangocms_frontend/contrib/image/forms.py
@@ -4,8 +4,7 @@ try:
     import filer
 except ImportError:
     raise ImproperlyConfigured(
-        "Image plugin requires django-filer. "
-        "Install it using: pip install djangocms-frontend[filer]"
+        "Image plugin requires django-filer. Install it using: pip install djangocms-frontend[filer]"
     )
 
 from django import forms

--- a/djangocms_frontend/contrib/image/forms.py
+++ b/djangocms_frontend/contrib/image/forms.py
@@ -1,3 +1,13 @@
+from django.core.exceptions import ImproperlyConfigured
+
+try:
+    import filer
+except ImportError:
+    raise ImproperlyConfigured(
+        "Image plugin requires django-filer. "
+        "Install it using: pip install djangocms-frontend[filer]"
+    )
+
 from django import forms
 from django.conf import settings as django_settings
 from django.db.models.fields.related import ManyToOneRel


### PR DESCRIPTION
### What was done
- Guarded django-filer imports in image and carousel plugins
- Added clear ImproperlyConfigured errors with installation guidance

### Why
Importing image or carousel plugins currently fails with ImportError when
django-filer is not installed. This change makes the dependency explicit
and improves developer experience.

### Scope
This PR is a first step toward disentangling django-filer by:
- Avoiding import-time crashes
- Making missing dependencies explicit at runtime

No behavior change for projects that already use django-filer.

Closes #25

## Summary by Sourcery

Bug Fixes:
- Prevent import-time crashes in image and carousel plugins when django-filer is not installed by guarding imports and raising ImproperlyConfigured errors.