### PR TITLE
feat: Add get_slot template filter

### DIFF
--- a/djangocms_frontend/templatetags/frontend.py
+++ b/djangocms_frontend/templatetags/frontend.py
@@ -314,6 +314,18 @@ class RenderChildPluginsTag(Tag):
         return content
 
 
+@register.filter
+def get_slot(instance, slot_name):
+    """Get plugins for a specific slot directly from the instance. This is useful for rendering slots in a component's template,
+    e.g. with {% for plugin in instance|get_slot:"community" %}.
+    Usage: {% for plugin in instance|get_slot:"community" %} ... {% endfor %}
+    """
+    plugin_type = f"{instance.__class__.__name__}{slot_name.capitalize()}Plugin"
+    for plugin in instance.child_plugin_instances:
+        if plugin.plugin_type == plugin_type:
+            yield from plugin.child_plugin_instances
+
+
 class InlineField(CMSEditableObject):
     name = "inline_field"
     options = Options(

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -503,6 +503,41 @@ plugins.
     but requires the user to select at least one device.
 
 *******************
+Template filters
+*******************
+
+``djangocms-frontend`` provides template filters that can be used in component templates.
+Load them with ``{% load frontend %}``.
+
+.. py:function:: get_slot(instance, slot_name)
+
+    Import from ``djangocms_frontend.templatetags.frontend``.
+
+    Get plugins for a specific slot directly from a component instance. This is useful 
+    for manually iterating over slot plugins in a component's template instead of using 
+    the ``{% childplugins %}`` template tag.
+
+    :param instance: The component plugin instance
+    :param slot_name: The name of the slot to retrieve plugins from
+    :return: Generator yielding child plugin instances in the specified slot
+
+    **Usage in templates:**
+
+    .. code-block:: django
+
+        {% load frontend %}
+        
+        {% for plugin in instance|get_slot:"buttons" %}
+            {# Manually render each plugin in the slot #}
+            <div class="button-wrapper">
+                {% render_plugin plugin %}
+            </div>
+        {% endfor %}
+
+    This is useful when you need more control over how slot content is rendered,
+    compared to the ``{% childplugins %}`` tag which handles rendering automatically.
+
+*******************
 Management commands
 *******************
 


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Add a get_slot template filter to access plugins for a specific slot directly from a component instance in templates.