### PR TITLE
feat: Allow custom defaults for plugins and components

### DIFF
--- a/djangocms_frontend/component_base.py
+++ b/djangocms_frontend/component_base.py
@@ -110,26 +110,30 @@ class CMSFrontendComponent(forms.Form):
             app_config = apps.get_containing_app_config(cls.__module__)
             if app_config is None:  # pragma: no cover
                 raise ValueError(f"Cannot find app_config for {cls.__module__}")
+            model_attrs = {
+                "Meta": type(
+                    "Meta",
+                    (),
+                    {
+                        "app_label": app_config.label,
+                        "proxy": True,
+                        "managed": False,
+                        "verbose_name": getattr(cls._component_meta, "name", cls.__name__),
+                    },
+                ),
+                "get_short_description": cls.get_short_description,
+                "__module__": cls.__module__,
+            }
+            default_config = getattr(cls._component_meta, "default_config", None)
+            if default_config:
+                model_attrs["default_config"] = default_config
             cls._model = type(
                 cls.__name__,
                 (
                     *cls._model_mixins,
                     FrontendUIItem,
                 ),
-                {
-                    "Meta": type(
-                        "Meta",
-                        (),
-                        {
-                            "app_label": app_config.label,
-                            "proxy": True,
-                            "managed": False,
-                            "verbose_name": getattr(cls._component_meta, "name", cls.__name__),
-                        },
-                    ),
-                    "get_short_description": cls.get_short_description,
-                    "__module__": cls.__module__,
-                },
+                model_attrs,
             )
         return cls._model
 

--- a/djangocms_frontend/models.py
+++ b/djangocms_frontend/models.py
@@ -6,7 +6,7 @@ from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
 
 from djangocms_frontend.fields import TagTypeField
-from djangocms_frontend.settings import FRAMEWORK_PLUGIN_INFO
+from djangocms_frontend.settings import FRAMEWORK_PLUGIN_INFO, PLUGIN_DEFAULTS
 
 
 class AbstractFrontendUIItem(CMSPlugin):
@@ -95,7 +95,10 @@ class AbstractFrontendUIItem(CMSPlugin):
         return super().save(*args, **kwargs)
 
     def initialize_from_form(self, form=None):
-        """Populates the config JSON field based on initial values provided by the fields of form"""
+        """Populates the config JSON field based on initial values provided by the fields of form.
+        After setting form defaults, applies per-model defaults from the model's ``default_config``
+        class attribute (if any), then from the ``DJANGOCMS_FRONTEND_PLUGIN_DEFAULTS`` setting
+        (keyed by model class name). Setting-based defaults take highest priority."""
         if form is None:
             form = self.get_plugin_class().form
         if isinstance(form, type):  # if is class
@@ -105,6 +108,12 @@ class AbstractFrontendUIItem(CMSPlugin):
         entangled_fields = getattr(getattr(form, "_meta", None), "entangled_fields", {}).get("config", ())
         for field in entangled_fields:
             self.config.setdefault(field, {} if field == "attributes" else form[field].initial or "")
+        # Apply model-level defaults (override form defaults)
+        for key, value in getattr(self, "default_config", {}).items():
+            self.config[key] = value
+        # Apply settings-level defaults (highest priority)
+        for key, value in PLUGIN_DEFAULTS.get(self.__class__.__name__, {}).items():
+            self.config[key] = value
         return self
 
     def get_short_description(self):

--- a/djangocms_frontend/settings.py
+++ b/djangocms_frontend/settings.py
@@ -76,6 +76,8 @@ SHOW_EMPTY_CHILDREN = getattr(django_settings, "DJANGOCMS_FRONTEND_SHOW_EMPTY_CH
 
 FORM_OPTIONS = getattr(django_settings, "DJANGOCMS_FRONTEND_FORM_OPTIONS", {})
 
+PLUGIN_DEFAULTS = getattr(django_settings, "DJANGOCMS_FRONTEND_PLUGIN_DEFAULTS", {})
+
 COMPONENT_FIELDS = getattr(django_settings, "DJANGOCMS_FRONTEND_COMPONENT_FIELDS", {})
 COMPONENT_FOLDER = getattr(django_settings, "DJANGOCMS_FRONTEND_COMPONENT_FOLDER", "cms_components")
 framework = getattr(django_settings, "DJANGOCMS_FRONTEND_FRAMEWORK", "bootstrap5")

--- a/docs/source/how-to/extend-frontend-plugins.rst
+++ b/docs/source/how-to/extend-frontend-plugins.rst
@@ -316,6 +316,114 @@ to its basic functionality, i.e. the background images will not be
 shown. As long as plugins are not edited the background image
 information will be preserved.
 
+.. index::
+    single: Plugin defaults
+    single: Default configuration
+
+.. _plugin-defaults:
+
+Configuring plugin defaults
+===========================
+
+When new plugin instances are created — either by an editor or automatically
+as child plugins — their configuration fields start with default values.
+``djangocms-frontend`` provides a three-level hierarchy for controlling
+these defaults, where each level overrides the previous one:
+
+1. **Form field initials** (lowest priority) — the ``initial`` parameter on
+   each form field. These are the built-in defaults shipped with
+   ``djangocms-frontend``.
+
+2. **Model ``default_config`` attribute** — a dictionary on the plugin's model
+   class. Use this when writing a theme or custom app to set sensible
+   defaults in code.
+
+3. **The** ``DJANGOCMS_FRONTEND_PLUGIN_DEFAULTS`` **setting** (highest
+   priority) — a project-level Django setting that lets site administrators
+   override defaults without touching any code.
+
+Editors can always change the values in the plugin form regardless of the
+defaults.
+
+Using ``DJANGOCMS_FRONTEND_PLUGIN_DEFAULTS``
+--------------------------------------------
+
+Add a dictionary to your project's ``settings.py`` keyed by plugin model
+class name. The inner dictionaries map config field names to their default
+values:
+
+.. code:: python
+
+    DJANGOCMS_FRONTEND_PLUGIN_DEFAULTS = {
+        "GridContainer": {
+            "padding_y": "py-5",
+        },
+        "GridColumn": {
+            "padding_x": "px-3",
+        },
+        "Alert": {
+            "alert_context": "info",
+        },
+    }
+
+The keys (e.g. ``"GridContainer"``, ``"Alert"``) are the proxy model class
+names defined in ``djangocms_frontend.contrib.*.models``. The field names
+(e.g. ``"padding_y"``, ``"alert_context"``) correspond to the entangled form
+field names — these are the same names visible in the plugin's admin form.
+
+For spacing fields the value format is ``"<property><side>-<size>"``, e.g.
+``"py-5"`` for vertical padding of size 5, or ``"mx-3"`` for horizontal
+margin of size 3.
+
+Using ``default_config`` on the model
+-------------------------------------
+
+When building a theme app or custom plugin, you can declare defaults
+directly on the model class:
+
+.. code:: python
+
+    from djangocms_frontend.models import FrontendUIItem
+
+    class GridContainer(FrontendUIItem):
+        default_config = {
+            "padding_y": "py-3",
+        }
+
+        class Meta:
+            proxy = True
+
+These defaults override form field initials but are themselves overridden
+by ``DJANGOCMS_FRONTEND_PLUGIN_DEFAULTS``. This makes ``default_config``
+useful for shipping opinionated defaults with a theme while still allowing
+site administrators to adjust them via the setting.
+
+.. tip::
+
+    Theme authors who do not define their own proxy models can set or update
+    ``default_config`` on existing models in their theme app's ``ready()``
+    method:
+
+    .. code:: python
+
+        # theme/apps.py
+        from django.apps import AppConfig
+
+
+        class ThemeConfig(AppConfig):
+            name = "theme"
+
+            def ready(self):
+                from djangocms_frontend.contrib.grid.models import GridContainer
+
+                GridContainer.default_config = {
+                    "padding_y": "py-3",
+                    "container_type": "container-fluid",
+                }
+
+    This approach works well when a theme wants to provide defaults for
+    built-in plugins without subclassing them.
+
 .. note::
 
     A few suggestions on extending ``djangocms-frontend``:

--- a/docs/source/reference/settings.rst
+++ b/docs/source/reference/settings.rst
@@ -366,6 +366,42 @@ in your project's ``settings.py``.
 
     This lost of options define the icon size choices a user can select. The values (first tuple element) are css units for the ``font-size`` css property. Besides relative units (``%``) any css unit can be used, e.g. ``112pt``.
 
+.. py:attribute:: settings.DJANGOCMS_FRONTEND_PLUGIN_DEFAULTS
+
+    Default: ``{}``
+
+    A dictionary of plugin model class names to default configuration values.
+    These defaults are applied when a new plugin instance is created (e.g. when
+    a plugin auto-creates child plugins). They override the form field defaults
+    but can still be changed by editors in the plugin form.
+
+    The keys of the inner dictionary correspond to the form field names (which
+    map to keys in the plugin's ``config`` JSON field). The values use the
+    same format as the form field's compressed value.
+
+    Example: to give all Container plugins a default vertical padding of 5 and
+    all Column plugins a default horizontal padding of 3::
+
+        DJANGOCMS_FRONTEND_PLUGIN_DEFAULTS = {
+            "GridContainer": {
+                "padding_y": "py-5",
+            },
+            "GridColumn": {
+                "padding_x": "px-3",
+            },
+        }
+
+    Plugin model class names correspond to the proxy model names defined in
+    ``djangocms_frontend.contrib.*.models`` (e.g. ``GridContainer``,
+    ``GridRow``, ``GridColumn``, ``Card``, ``CardLayout``, ``Alert``, etc.).
+
+    .. note::
+
+        Plugin models can also declare a ``default_config`` class attribute
+        (a dictionary with the same format) to provide code-level defaults.
+        The priority order is: form field initials (lowest) < model
+        ``default_config`` < ``DJANGOCMS_FRONTEND_PLUGIN_DEFAULTS`` (highest).
+
 .. py:attribute:: settings.DJANGOCMS_FRONTEND_SHOW_EMPTY_CHILDREN
 
     Default: ``False``

--- a/docs/source/tutorial/custom_components.rst
+++ b/docs/source/tutorial/custom_components.rst
@@ -259,6 +259,84 @@ To define fieldsets, add a ``fieldsets`` attribute to the component's ``Meta`` c
 If you don't define ``fieldsets``, all fields will be shown in a single unnamed fieldset.
 
 
+Setting default field values
+============================
+
+When a new component instance is created, its fields are initialized with
+the ``initial`` values declared on each form field. You can override these
+defaults on a per-component basis by adding a ``default_config`` dictionary
+to the component's ``Meta`` class:
+
+.. code-block:: python
+
+    @components.register
+    class MyCard(CMSFrontendComponent):
+        class Meta:
+            name = "Card"
+            render_template = "card.html"
+            default_config = {
+                "background_color": "#f8f9fa",
+                "text_color": "#212529",
+            }
+
+        title = forms.CharField(required=True)
+        background_color = forms.CharField(required=False, initial="#ffffff")
+        text_color = forms.CharField(required=False, initial="#000000")
+
+In this example, new Card instances will start with ``background_color``
+set to ``#f8f9fa`` instead of the form field's ``initial`` value of
+``#ffffff``. Editors can still change the value in the plugin form.
+
+This is especially useful for fields that come from mixins, such as
+``Background``, ``Spacing``, ``Responsive``, or ``Sizing``. Since mixin
+fields are defined elsewhere, you cannot change their ``initial`` values
+in your component class. ``default_config`` lets you set sensible defaults
+for these fields without having to redefine them:
+
+.. code-block:: python
+
+    @components.register
+    class MySection(CMSFrontendComponent):
+        class Meta:
+            name = "Section"
+            render_template = "section.html"
+            mixins = ["Background", "Spacing"]
+            default_config = {
+                "background_context": "light",
+                "padding_y": "py-5",
+                "margin_y": "my-3",
+            }
+
+        heading = forms.CharField(required=True)
+
+Here, the ``background_context``, ``padding_y``, and ``margin_y`` fields
+are all contributed by the ``Background`` and ``Spacing`` mixins. Without
+``default_config``, they would start empty.
+
+Defaults are applied in the following priority order (highest wins):
+
+1. **Form field** ``initial`` **values** — the built-in baseline.
+2. **Meta** ``default_config`` — component-level overrides set by
+   the developer.
+3. **The** :py:attr:`~settings.DJANGOCMS_FRONTEND_PLUGIN_DEFAULTS`
+   **setting** — project-level overrides set by the site administrator.
+
+This means a site administrator can always fine-tune defaults via the
+Django setting without modifying component code:
+
+.. code-block:: python
+
+    # settings.py
+    DJANGOCMS_FRONTEND_PLUGIN_DEFAULTS = {
+        "MyCard": {
+            "background_color": "#ffffff",
+        },
+    }
+
+For more details on the setting, see
+:py:attr:`~settings.DJANGOCMS_FRONTEND_PLUGIN_DEFAULTS`.
+
+
 Limitations of custom frontend components
 =========================================
 

--- a/tests/component/test_models.py
+++ b/tests/component/test_models.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.test import TestCase
 
 from djangocms_frontend.component_pool import components
@@ -11,3 +13,52 @@ class ComponentPluginTestCase(TestCase):
         instance.initialize_from_form(MyHeroPlugin.form)
 
         self.assertEqual(instance.get_short_description(), "my title")
+
+
+class ComponentDefaultConfigTestCase(TestCase):
+    """Tests that default_config in a component's Meta class is applied to the generated model."""
+
+    def test_meta_default_config_is_set_on_model(self):
+        """The generated proxy model has the default_config from Meta."""
+        MyDefaultsComponent, _, _ = components["MyDefaultsComponent"]
+        self.assertEqual(
+            MyDefaultsComponent.default_config,
+            {"title": "Default Title", "color": "primary"},
+        )
+
+    def test_default_config_overrides_form_initials(self):
+        """Meta default_config overrides form field initial values."""
+        MyDefaultsComponent, MyDefaultsComponentPlugin, _ = components["MyDefaultsComponent"]
+        instance = MyDefaultsComponent.objects.create()
+        instance.initialize_from_form(MyDefaultsComponentPlugin.form)
+        # default_config overrides form initials
+        self.assertEqual(instance.config["title"], "Default Title")
+        self.assertEqual(instance.config["color"], "primary")
+        # Fields not in default_config keep form initials
+        self.assertEqual(instance.config["extra"], "form-extra")
+
+    @patch(
+        "djangocms_frontend.models.PLUGIN_DEFAULTS",
+        {
+            "MyDefaultsComponent": {"title": "Settings Title"},
+        },
+    )
+    def test_settings_override_meta_default_config(self):
+        """PLUGIN_DEFAULTS setting overrides Meta default_config."""
+        MyDefaultsComponent, MyDefaultsComponentPlugin, _ = components["MyDefaultsComponent"]
+        instance = MyDefaultsComponent.objects.create()
+        instance.initialize_from_form(MyDefaultsComponentPlugin.form)
+        # Settings win over Meta default_config
+        self.assertEqual(instance.config["title"], "Settings Title")
+        # Meta default_config still applies for fields not in settings
+        self.assertEqual(instance.config["color"], "primary")
+        # Form initials still apply for fields not in either
+        self.assertEqual(instance.config["extra"], "form-extra")
+
+    def test_component_without_default_config(self):
+        """Components without default_config in Meta work normally."""
+        MyHero, MyHeroPlugin, _ = components["MyHero"]
+        self.assertFalse(hasattr(MyHero, "default_config"))
+        instance = MyHero.objects.create()
+        instance.initialize_from_form(MyHeroPlugin.form)
+        self.assertEqual(instance.config["title"], "my title")

--- a/tests/grid/test_models.py
+++ b/tests/grid/test_models.py
@@ -1,7 +1,103 @@
+from unittest.mock import patch
+
 from django.test import TestCase
 
 from djangocms_frontend.contrib.grid.forms import GridColumnForm, GridContainerForm
 from djangocms_frontend.contrib.grid.models import GridColumn, GridContainer, GridRow
+
+
+class PluginDefaultsHierarchyTestCase(TestCase):
+    """Tests for the three-level plugin defaults hierarchy:
+    form field initials < model default_config < DJANGOCMS_FRONTEND_PLUGIN_DEFAULTS setting."""
+
+    def test_form_field_defaults_are_applied(self):
+        """Level 1: Form field initial values are applied by initialize_from_form."""
+        instance = GridContainer.objects.create()
+        instance.initialize_from_form(GridContainerForm)
+        # container_type should get the form field's initial value
+        self.assertEqual(instance.config["container_type"], "container")
+        # spacing fields default to empty
+        self.assertEqual(instance.config.get("padding_y", ""), "")
+
+    def test_model_default_config_overrides_form_defaults(self):
+        """Level 2: Model default_config overrides form field initials."""
+        instance = GridContainer.objects.create()
+        original = getattr(GridContainer, "default_config", {})
+        try:
+            GridContainer.default_config = {
+                "container_type": "container-fluid",
+                "padding_y": "py-5",
+            }
+            instance.initialize_from_form(GridContainerForm)
+            self.assertEqual(instance.config["container_type"], "container-fluid")
+            self.assertEqual(instance.config["padding_y"], "py-5")
+        finally:
+            if original:
+                GridContainer.default_config = original
+            else:
+                del GridContainer.default_config
+
+    @patch(
+        "djangocms_frontend.models.PLUGIN_DEFAULTS",
+        {
+            "GridContainer": {"container_type": "container-full", "padding_x": "px-3"},
+        },
+    )
+    def test_settings_defaults_override_form_defaults(self):
+        """Level 3: PLUGIN_DEFAULTS setting overrides form field initials."""
+        instance = GridContainer.objects.create()
+        instance.initialize_from_form(GridContainerForm)
+        self.assertEqual(instance.config["container_type"], "container-full")
+        self.assertEqual(instance.config["padding_x"], "px-3")
+
+    @patch(
+        "djangocms_frontend.models.PLUGIN_DEFAULTS",
+        {
+            "GridContainer": {"container_type": "container-full"},
+        },
+    )
+    def test_settings_override_model_default_config(self):
+        """Level 3 beats level 2: settings override model default_config."""
+        instance = GridContainer.objects.create()
+        original = getattr(GridContainer, "default_config", {})
+        try:
+            GridContainer.default_config = {
+                "container_type": "container-fluid",
+                "padding_y": "py-5",
+            }
+            instance.initialize_from_form(GridContainerForm)
+            # Setting wins over model default_config for container_type
+            self.assertEqual(instance.config["container_type"], "container-full")
+            # Model default_config still applies for fields not in settings
+            self.assertEqual(instance.config["padding_y"], "py-5")
+        finally:
+            if original:
+                GridContainer.default_config = original
+            else:
+                del GridContainer.default_config
+
+    @patch("djangocms_frontend.models.PLUGIN_DEFAULTS", {})
+    def test_unrelated_model_not_affected(self):
+        """PLUGIN_DEFAULTS for one model do not affect other models."""
+        instance = GridColumn.objects.create()
+        instance.initialize_from_form(GridColumnForm)
+        # GridColumn should only have its own form defaults
+        self.assertNotIn("container_type", instance.config)
+
+    @patch(
+        "djangocms_frontend.models.PLUGIN_DEFAULTS",
+        {
+            "GridContainer": {"padding_y": "py-5"},
+        },
+    )
+    def test_form_defaults_preserved_for_non_overridden_fields(self):
+        """Fields not mentioned in higher layers keep their form defaults."""
+        instance = GridContainer.objects.create()
+        instance.initialize_from_form(GridContainerForm)
+        # container_type should still have the form default
+        self.assertEqual(instance.config["container_type"], "container")
+        # padding_y overridden by settings
+        self.assertEqual(instance.config["padding_y"], "py-5")
 
 
 class GridModelTestCase(TestCase):

--- a/tests/test_app/cms_components.py
+++ b/tests/test_app/cms_components.py
@@ -50,6 +50,22 @@ class MyStrangeComponent(CMSFrontendComponent):
 
 
 @components.register
+class MyDefaultsComponent(CMSFrontendComponent):
+    class Meta:
+        name = "Defaults Test"
+        render_template = "hero.html"
+        allow_children = False
+        default_config = {
+            "title": "Default Title",
+            "color": "primary",
+        }
+
+    title = forms.CharField(required=False, initial="Form Title")
+    color = forms.CharField(required=False, initial="secondary")
+    extra = forms.CharField(required=False, initial="form-extra")
+
+
+@components.register
 class MyCardWithFieldsets(CMSFrontendComponent):
     class Meta:
         name = "Card with Fieldsets"


### PR DESCRIPTION
## Summary by Sourcery

Introduce a configurable defaults hierarchy for frontend plugins and components, allowing form initials, model-level defaults, and project-level settings to determine initial plugin configuration.

New Features:
- Add support for per-plugin default configuration via a DJANGOCMS_FRONTEND_PLUGIN_DEFAULTS setting keyed by model class name.
- Allow components to define a Meta.default_config that is applied to their generated proxy models and used when initializing plugin instances.

Enhancements:
- Extend AbstractFrontendUIItem.initialize_from_form to merge form field initials with model-level and settings-level defaults in a defined precedence order.
- Propagate Meta.default_config from CMSFrontendComponent definitions into dynamically generated plugin models.

Tests:
- Add comprehensive tests covering the three-level defaults hierarchy for grid plugins and for component Meta.default_config, including precedence and isolation between models.

fixes: https://github.com/django-cms/django-cms.org/issues/145