### PR TITLE
fix: picture now use filer thumbnail option if set

### DIFF
--- a/djangocms_frontend/contrib/image/models.py
+++ b/djangocms_frontend/contrib/image/models.py
@@ -112,7 +112,6 @@ class Image(GetLinkMixin, ImageMixin, FrontendUIItem):
 
     @cached_property
     def img_src(self):
-        picture_options = self.get_size()
         # we want the external image to take priority by design
         # please open a ticket if you disagree for an open discussion
         if self.external_picture:
@@ -123,9 +122,12 @@ class Image(GetLinkMixin, ImageMixin, FrontendUIItem):
             return ""
         # skip image processing when there's no width or height defined,
         # or when legacy use_no_cropping flag is present
-        elif getattr(self, "use_no_cropping", None) or not (self.width or self.height or getattr(self, "thumbnail_options"):
+        elif getattr(self, "use_no_cropping", None) or not (
+            self.width or self.height or getattr(self, "thumbnail_options")
+        ):
             return self.rel_image.url if self.rel_image else ""
 
+        picture_options = self.get_size()
         thumbnail_options = {
             "size": picture_options["size"],
             "crop": picture_options["crop"],

--- a/djangocms_frontend/contrib/image/models.py
+++ b/djangocms_frontend/contrib/image/models.py
@@ -112,6 +112,10 @@ class Image(GetLinkMixin, ImageMixin, FrontendUIItem):
 
     @cached_property
     def img_src(self):
+        picture_options = self.get_size(
+            width=self.width or 0,
+            height=self.height or 0,
+        )
         # we want the external image to take priority by design
         # please open a ticket if you disagree for an open discussion
         if self.external_picture:
@@ -122,13 +126,8 @@ class Image(GetLinkMixin, ImageMixin, FrontendUIItem):
             return ""
         # skip image processing when there's no width or height defined,
         # or when legacy use_no_cropping flag is present
-        elif getattr(self, "use_no_cropping", None) or not (self.width or self.height):
+        elif getattr(self, "use_no_cropping", None) or not (picture_options["size"][0] or picture_options["size"][1]):
             return self.rel_image.url if self.rel_image else ""
-
-        picture_options = self.get_size(
-            width=self.width or 0,
-            height=self.height or 0,
-        )
 
         thumbnail_options = {
             "size": picture_options["size"],

--- a/djangocms_frontend/contrib/image/models.py
+++ b/djangocms_frontend/contrib/image/models.py
@@ -123,7 +123,7 @@ class Image(GetLinkMixin, ImageMixin, FrontendUIItem):
             return ""
         # skip image processing when there's no width or height defined,
         # or when legacy use_no_cropping flag is present
-        elif getattr(self, "use_no_cropping", None) or not (picture_options["size"][0] or picture_options["size"][1]):
+        elif getattr(self, "use_no_cropping", None) or not (self.width or self.height or getattr(self, "thumbnail_options"):
             return self.rel_image.url if self.rel_image else ""
 
         thumbnail_options = {

--- a/djangocms_frontend/contrib/image/models.py
+++ b/djangocms_frontend/contrib/image/models.py
@@ -112,10 +112,7 @@ class Image(GetLinkMixin, ImageMixin, FrontendUIItem):
 
     @cached_property
     def img_src(self):
-        picture_options = self.get_size(
-            width=self.width or 0,
-            height=self.height or 0,
-        )
+        picture_options = self.get_size()
         # we want the external image to take priority by design
         # please open a ticket if you disagree for an open discussion
         if self.external_picture:


### PR DESCRIPTION
Move picture_options definition before the if/elif block, and use picture_options["size"] in the if that was reached before if no width/height was set for the image (but a thumbnail option was choosen).

Fixes #359.

## Summary by Sourcery

Bug Fixes:
- Fix image source generation to fall back to computed picture size when width and height are not explicitly provided, preventing unintended skipping of image processing.