### PR TITLE
fix: Avoid copying compiled templates

### DIFF
--- a/djangocms_frontend/models.py
+++ b/djangocms_frontend/models.py
@@ -1,7 +1,8 @@
 from cms.models import CMSPlugin
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
-from django.utils.html import conditional_escape, mark_safe
+from django.utils.html import conditional_escape
+from django.utils.safestring import mark_safe
 from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
 
@@ -46,7 +47,7 @@ class AbstractFrontendUIItem(CMSPlugin):
 
     def __init__(self, *args, **kwargs):
         self._additional_classes = []
-        self.html_id = None  # HTML id attribute will be set in template tag set_html_id.
+        self.html_id: str | None = None  # HTML id attribute will be set in template tag set_html_id.
         super().__init__(*args, **kwargs)
 
     def __getattr__(self, item):

--- a/djangocms_frontend/plugin_tag.py
+++ b/djangocms_frontend/plugin_tag.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import copy
 import importlib
 import warnings
 
@@ -51,15 +50,13 @@ def render_dummy_plugin(context, dummy_plugin):
     return dummy_plugin.nodelist.render(context)
 
 
-def patch_template(template):
+def patched_template(template_name: str):
     """Patches the template to use the dummy plugin renderer instead of the real one."""
-    copied_template = copy.deepcopy(template)
-    patch = False
-    for node in copied_template.template.nodelist.get_nodes_by_type(SimpleNode):
+    template = get_template(template_name)  # Gives a freshly compiled template object
+    for node in template.template.nodelist.get_nodes_by_type(SimpleNode):
         if node.func == render_plugin:
-            patch = True
             node.func = render_dummy_plugin
-    return copied_template if patch else template
+    return template
 
 
 def get_plugin_class(settings_string: str | type) -> type:
@@ -90,13 +87,12 @@ def setup():
                 instance.initialize_from_form(plugin.form)
             if tag_name not in plugin_tag_pool:
                 template_name = plugin_admin._get_render_template({"request": None}, instance, None)
-                template = get_template(template_name)
                 plugin_tag_pool[tag_name] = {
                     "defaults": {
                         **_get_plugindefaults(instance),
                         **dict(plugin_type=plugin.__name__),
                     },
-                    "templates": {template_name: patch_template(template)},
+                    "templates": {template_name: patched_template(template_name)},
                     "class": plugin,
                 }
             else:  # pragma: no cover

--- a/djangocms_frontend/plugin_tag.py
+++ b/djangocms_frontend/plugin_tag.py
@@ -50,9 +50,21 @@ def render_dummy_plugin(context, dummy_plugin):
     return dummy_plugin.nodelist.render(context)
 
 
+def get_recompiled_template(template_name: str):
+    """Get a recompiled template to ensure that the patched render_plugin is used."""
+    template = get_template(template_name)
+    origin = template.origin
+    if not origin or not origin.loader:
+        raise ValueError("Template has no origin/loader (cannot recompile)")
+
+    source = origin.loader.get_contents(origin)
+    # Compile a fresh Template instance
+    return template.backend.from_string(source)
+
+
 def patched_template(template_name: str):
     """Patches the template to use the dummy plugin renderer instead of the real one."""
-    template = get_template(template_name)  # Gives a freshly compiled template object
+    template = get_recompiled_template(template_name)  # Gives a freshly compiled template object
     for node in template.template.nodelist.get_nodes_by_type(SimpleNode):
         if node.func == render_plugin:
             node.func = render_dummy_plugin

--- a/djangocms_frontend/plugin_tag.py
+++ b/djangocms_frontend/plugin_tag.py
@@ -53,11 +53,7 @@ def render_dummy_plugin(context, dummy_plugin):
 def get_recompiled_template(template_name: str):
     """Get a recompiled template to ensure that the patched render_plugin is used."""
     template = get_template(template_name)
-    origin = template.origin
-    if not origin or not origin.loader:
-        raise ValueError("Template has no origin/loader (cannot recompile)")
-
-    source = origin.loader.get_contents(origin)
+    source = template.origin.loader.get_contents(template.origin)
     # Compile a fresh Template instance
     return template.backend.from_string(source)
 

--- a/djangocms_frontend/templatetags/frontend.py
+++ b/djangocms_frontend/templatetags/frontend.py
@@ -17,15 +17,16 @@ from django.http import HttpRequest
 from django.template.defaultfilters import safe
 from django.utils.encoding import force_str
 from django.utils.functional import Promise
-from django.utils.html import conditional_escape, mark_safe
+from django.utils.html import conditional_escape
 from django.utils.module_loading import import_string
+from django.utils.safestring import mark_safe
 from entangled.forms import EntangledModelFormMixin
 
 from djangocms_frontend import settings
 from djangocms_frontend.fields import HTMLsanitized
 from djangocms_frontend.helpers import get_related_object as related_object
 from djangocms_frontend.models import FrontendUIItem
-from djangocms_frontend.plugin_tag import get_template, patch_template
+from djangocms_frontend.plugin_tag import patched_template
 
 register = template.Library()
 
@@ -243,16 +244,12 @@ class Plugin(AsTag):
         # Replace inner plugins with the nodelist, i.e. the content within the plugin tag
         instance.child_plugin_instances = DummyPlugin(nodelist, instance.plugin_type).get_instances()
         # ... and render (see cms.plugin_rendering.ContentRenderer)
-        template_name = plugin._get_render_template(context, instance, None)
-        if template_name not in plugin_tag_pool[name]["templates"]:
-            plugin_tag_pool[name]["templates"][template_name] = patch_template(get_template(template_name))
-
         context = PluginContext(context, instance, None)
         context = plugin.render(context, instance, "slot")
         context = flatten_context(context)
         template_name = plugin._get_render_template(context, instance, None)
         if template_name not in plugin_tag_pool[name]["templates"]:
-            plugin_tag_pool[name]["templates"][template_name] = patch_template(get_template(template_name))
+            plugin_tag_pool[name]["templates"][template_name] = patched_template(template_name)
         template = plugin_tag_pool[name]["templates"][template_name]
         content = template.render(context)
 


### PR DESCRIPTION
## Summary by Sourcery

Ensure plugin templates are recompiled instead of deep-copied so that patched dummy plugin rendering is consistently applied, and make minor type and import cleanups.

Bug Fixes:
- Prevent reuse of compiled Django templates by deep copy to avoid inconsistencies when swapping the plugin render function with a dummy renderer.

Enhancements:
- Introduce a helper to recompile templates by name and use it wherever patched plugin templates are needed.
- Tighten typing of the FrontendUIItem html_id attribute and clean up safestring-related imports.