### PR TITLE
chore: Prepare release 2.4.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ Changelog
 * feat: Allow disabling of the Advanced Settings tab to hide technical details by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/363
 * feat: Allow custom defaults for plugins and components by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/356
 * fix: Allow change_form_template for components by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/352
-* fix: picture now use filer thumbnail option if set by @corentinbettiol in https://github.com/django-cms/djangocms-frontend/pull/360
+* fix: picture now uses filer thumbnail option if set by @corentinbettiol in https://github.com/django-cms/djangocms-frontend/pull/360
 * fix: plugin template tag ignored dynamic templates by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/361
 * fix: Avoid copying compiled templates by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/362
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,19 @@
 Changelog
 =========
 
+
+2.4.0 (2026.03-27
+==================
+
+* feat: add "target" option to link plugin by @corentinbettiol in https://github.com/django-cms/djangocms-frontend/pull/355
+* feat: Make slots more recognizable in the plugin tree by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/357
+* feat: Allow disabling of the Advanced Settings tab to hide technical details by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/363
+* feat: Allow custom defaults for plugins and components by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/356
+* fix: Allow change_form_template for components by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/352
+* fix: picture now use filer thumbnail option if set by @corentinbettiol in https://github.com/django-cms/djangocms-frontend/pull/360
+* fix: plugin template tag ignored dynamic templates by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/361
+* fix: Avoid copying compiled templates by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/362
+
 2.3.1 (2026-03-12)
 ==================
 

--- a/djangocms_frontend/__init__.py
+++ b/djangocms_frontend/__init__.py
@@ -19,4 +19,4 @@ Release logic:
 13. Github actions will publish the new package to pypi
 """
 
-__version__ = "2.3.1"
+__version__ = "2.4.0"

--- a/docs/source/reference/management-commands.rst
+++ b/docs/source/reference/management-commands.rst
@@ -31,3 +31,22 @@ project directory. ``command`` can be one of the following:
     Permissions are copied from the ``FrontendUIItem`` model to all installed
     plugins. This way you can set permissions for all plugins by setting them
     for ``FrontendUIItem`` and then syncing them.
+
+.. _clear_advanced_settings:
+
+``clear_advanced_settings``
+    Removes all advanced settings from every djangocms-frontend plugin instance
+    in the database. Specifically it:
+
+    - Clears the ``attributes`` config (custom HTML attributes and classes) on
+      each plugin.
+    - Resets ``tag_type`` to the default value (``div``) for every plugin whose
+      tag type was changed.
+
+    This is useful after setting
+    :py:attr:`~settings.DJANGOCMS_FRONTEND_SHOW_ADVANCED_SETTINGS` to
+    ``False`` to ensure no orphaned advanced settings remain in the database.
+
+    Run with ``--noinput`` to skip the confirmation prompt::
+
+        python -m manage frontend clear_advanced_settings --noinput

--- a/docs/source/reference/settings.rst
+++ b/docs/source/reference/settings.rst
@@ -409,3 +409,34 @@ in your project's ``settings.py``.
     If set to ``True`` the frontend editing will show a message where children
     can be added to plugins to complete the design. This is supposed to make
     the editing experience more intuitive for editors.
+
+.. py:attribute:: settings.DJANGOCMS_FRONTEND_SHOW_ADVANCED_SETTINGS
+
+    Default: ``True``
+
+    Controls whether the "Advanced settings" tab is available in plugin edit
+    forms. Advanced settings allow editors to set custom HTML attributes (such
+    as ``id``, ``class``, ``data-*``, ``style``) and change the HTML tag type
+    of a plugin.
+
+    Set to ``False`` to hide the tab **and** suppress all user-configured
+    advanced settings at render time:
+
+    * The "Advanced settings" fieldset is removed from plugin admin forms.
+    * Custom HTML attributes stored in the plugin's ``attributes`` config are
+      ignored during rendering.
+    * User-specified CSS classes (set through the attributes field) are not
+      applied. Programmatically added classes (e.g. from spacing, responsive,
+      or background mixins) continue to work.
+    * The ``tag_type`` is reset to the default (``div``) at render time,
+      regardless of the value stored in the database.
+
+    .. note::
+
+        Disabling this setting does **not** remove existing advanced settings
+        from the database. To clean up previously stored values use the
+        :ref:`clear_advanced_settings` management command.
+
+    Example::
+
+        DJANGOCMS_FRONTEND_SHOW_ADVANCED_SETTINGS = False


### PR DESCRIPTION
## Summary by Sourcery

Prepare the project for the 2.4.0 release.

Build:
- Bump the package version from 2.3.1 to 2.4.0 in the package metadata.

Documentation:
- Update changelog and reference documentation for the 2.4.0 release.