### PR TITLE
fix: Add form ignored `dafault_config`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -170,7 +170,7 @@ See `LICENSE <https://github.com/django-cms/djangocms-frontend/blob/master/LICEN
     :target: https://djangocms-frontend.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
-.. |coverage| image:: https://codecov.io/gh/fsbraun/djangocms-frontend/branch/master/graph/badge.svg
+.. |coverage| image:: https://codecov.io/gh/fsbraun/djangocms-frontend/branch/main/graph/badge.svg
    :target: https://codecov.io/gh/django-cms/djangocms-frontend
 
 .. |python| image:: https://img.shields.io/pypi/pyversions/djangocms-frontend

--- a/djangocms_frontend/ui_plugin_base.py
+++ b/djangocms_frontend/ui_plugin_base.py
@@ -4,6 +4,7 @@ from django.utils.encoding import force_str
 
 from djangocms_frontend.helpers import get_related
 from djangocms_frontend.models import AbstractFrontendUIItem
+from djangocms_frontend.settings import PLUGIN_DEFAULTS
 
 try:
     from cms.admin.placeholderadmin import PlaceholderAdmin
@@ -29,6 +30,22 @@ class CMSUIPluginBase(FrontendEditableAdminMixin, CMSPluginBase):
 
     def __str__(self):
         return force_str(super().__str__())
+
+    def get_form(self, request, obj=None, change=False, **kwargs):
+        form_cls = super().get_form(request, obj, change, **kwargs)
+        if change:
+            return form_cls
+        # On add: apply default_config and PLUGIN_DEFAULTS as field initials
+        defaults = {}
+        defaults.update(getattr(self.model, "default_config", {}))
+        defaults.update(PLUGIN_DEFAULTS.get(self.model.__name__, {}))
+        if not defaults:
+            return form_cls
+        entangled_fields = getattr(getattr(form_cls, "_meta", None), "entangled_fields", {}).get("config", ())
+        for field_name, value in defaults.items():
+            if field_name in form_cls.base_fields and field_name in entangled_fields:
+                form_cls.base_fields[field_name].initial = value
+        return form_cls
 
     def render(self, context, instance, placeholder):
         if isinstance(instance, AbstractFrontendUIItem):

--- a/djangocms_frontend/ui_plugin_base.py
+++ b/djangocms_frontend/ui_plugin_base.py
@@ -36,14 +36,14 @@ class CMSUIPluginBase(FrontendEditableAdminMixin, CMSPluginBase):
         if change:
             return form_cls
         # On add: apply default_config and PLUGIN_DEFAULTS as field initials
+        # It is safe to modify the form_cls as it is a fresh class created for this request in get_form of the plugin base
         defaults = {}
         defaults.update(getattr(self.model, "default_config", {}))
         defaults.update(PLUGIN_DEFAULTS.get(self.model.__name__, {}))
         if not defaults:
             return form_cls
-        entangled_fields = getattr(getattr(form_cls, "_meta", None), "entangled_fields", {}).get("config", ())
         for field_name, value in defaults.items():
-            if field_name in form_cls.base_fields and field_name in entangled_fields:
+            if field_name in form_cls.base_fields:
                 form_cls.base_fields[field_name].initial = value
         return form_cls
 

--- a/tests/grid/test_models.py
+++ b/tests/grid/test_models.py
@@ -1,7 +1,8 @@
 from unittest.mock import patch
 
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
 
+from djangocms_frontend.contrib.grid.cms_plugins import GridContainerPlugin
 from djangocms_frontend.contrib.grid.forms import GridColumnForm, GridContainerForm
 from djangocms_frontend.contrib.grid.models import GridColumn, GridContainer, GridRow
 
@@ -98,6 +99,77 @@ class PluginDefaultsHierarchyTestCase(TestCase):
         self.assertEqual(instance.config["container_type"], "container")
         # padding_y overridden by settings
         self.assertEqual(instance.config["padding_y"], "py-5")
+
+
+class GetFormDefaultsTestCase(TestCase):
+    """Tests that get_form applies default_config and PLUGIN_DEFAULTS as field initials."""
+
+    def _get_form_instance(self, plugin_cls):
+        """Helper to get an instantiated form from a plugin's get_form (add mode)."""
+        request = RequestFactory().get("/")
+        plugin = plugin_cls()
+        form_cls = plugin.get_form(request, obj=None, change=False)
+        return form_cls()
+
+    def test_no_defaults_returns_original_form(self):
+        """Without any defaults, get_form returns the original form class."""
+        request = RequestFactory().get("/")
+        plugin = GridContainerPlugin()
+        form_cls = plugin.get_form(request, obj=None, change=False)
+        self.assertEqual(form_cls.__name__, GridContainerForm.__name__)
+
+    def test_model_default_config_sets_initial(self):
+        original = getattr(GridContainer, "default_config", {})
+        try:
+            GridContainer.default_config = {"container_type": "container-fluid"}
+            form = self._get_form_instance(GridContainerPlugin)
+            self.assertEqual(form.fields["container_type"].initial, "container-fluid")
+        finally:
+            if original:
+                GridContainer.default_config = original
+            else:
+                del GridContainer.default_config
+
+    @patch(
+        "djangocms_frontend.ui_plugin_base.PLUGIN_DEFAULTS",
+        {"GridContainer": {"container_type": "container-full"}},
+    )
+    def test_plugin_defaults_setting_sets_initial(self):
+        form = self._get_form_instance(GridContainerPlugin)
+        self.assertEqual(form.fields["container_type"].initial, "container-full")
+
+    @patch(
+        "djangocms_frontend.ui_plugin_base.PLUGIN_DEFAULTS",
+        {"GridContainer": {"container_type": "from-settings"}},
+    )
+    def test_settings_override_model_default_config_in_form(self):
+        original = getattr(GridContainer, "default_config", {})
+        try:
+            GridContainer.default_config = {"container_type": "from-model"}
+            form = self._get_form_instance(GridContainerPlugin)
+            self.assertEqual(form.fields["container_type"].initial, "from-settings")
+        finally:
+            if original:
+                GridContainer.default_config = original
+            else:
+                del GridContainer.default_config
+
+    def test_change_form_does_not_override_initials(self):
+        """On edit (change=True), defaults should NOT be applied."""
+        original = getattr(GridContainer, "default_config", {})
+        try:
+            GridContainer.default_config = {"container_type": "container-fluid"}
+            request = RequestFactory().get("/")
+            plugin = GridContainerPlugin()
+            form_cls = plugin.get_form(request, obj=None, change=True)
+            form = form_cls()
+            # Should have the original form field initial, not the default_config value
+            self.assertNotEqual(form.fields["container_type"].initial, "container-fluid")
+        finally:
+            if original:
+                GridContainer.default_config = original
+            else:
+                del GridContainer.default_config
 
 
 class GridModelTestCase(TestCase):


### PR DESCRIPTION
## Summary by Sourcery

Apply model and plugin default configuration to plugin add forms while ensuring edit forms keep existing initials.

Bug Fixes:
- Ensure plugin add forms respect model-level default_config and PLUGIN_DEFAULTS when initializing entangled config fields.
- Avoid overriding field initials on change (edit) forms so existing instance values are preserved.

Tests:
- Add test coverage for applying model default_config and PLUGIN_DEFAULTS to form field initials and for not applying them on change forms.