### PR TITLE
fix: plugin template tag calls were not isolated

### DIFF
--- a/djangocms_frontend/templatetags/frontend.py
+++ b/djangocms_frontend/templatetags/frontend.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import typing
 import uuid
@@ -219,7 +220,7 @@ class Plugin(AsTag):
                 f'To use "{name}" with the {{% plugin %}} template tag, add its plugin class to '
                 f"the CMS_COMPONENT_PLUGINS setting"
             )
-        field_values = plugin_tag_pool[name]["defaults"]
+        field_values = copy.deepcopy(plugin_tag_pool[name]["defaults"])
         plugin = plugin_tag_pool[name]["class"]()
 
         if issubclass(plugin.form, EntangledModelFormMixin):

--- a/tests/test_plugin_tag.py
+++ b/tests/test_plugin_tag.py
@@ -130,6 +130,20 @@ class PluginTagTestCase(TestFixture, CMSTestCase):
 
         self.assertInHTML(expected_result, result)
 
+    def test_kwargs_do_not_leak_between_plugin_calls(self):
+        """Regression test: kwargs from one {% plugin %} call must not
+        bleed into subsequent calls of the same plugin type."""
+        template = django_engine.from_string("""{% load frontend %}
+        {% plugin "alert" alert_context="warning" %}First{% endplugin %}
+        {% plugin "alert" %}Second{% endplugin %}
+        """)
+
+        result = template.render({"request": None})
+
+        # The second alert should use the default context ("primary"), not "warning"
+        self.assertIn("alert-warning", result)
+        self.assertIn("alert-primary", result)
+
     def test_autohero_component_registered_for_plugin_tag(self):
         from cms.plugin_pool import plugin_pool
 


### PR DESCRIPTION
## Summary by Sourcery

Ensure plugin template tag calls are isolated so arguments do not leak between invocations of the same plugin type.

Bug Fixes:
- Prevent plugin tag default field values from being shared and mutated across calls by deep-copying stored defaults.
- Add a regression test to verify that keyword arguments from one plugin tag invocation do not affect subsequent invocations.