### PR TITLE
fix: Read-only placeholders rendered inline fields editable

### DIFF
--- a/djangocms_frontend/templatetags/frontend.py
+++ b/djangocms_frontend/templatetags/frontend.py
@@ -362,7 +362,10 @@ class InlineField(CMSEditableObject):
         placeholder_editable = (
             isinstance(instance, CMSPlugin)
             and instance.pk
-            and instance.placeholder.check_source(context["request"].user)
+            and (
+                not hasattr(instance.placeholder, "check_source")  # django CMS 3.11 does not have check_source
+                or instance.placeholder.check_source(context["request"].user)  # Otherwise needs to apss
+            )
         )
 
         if is_registering_component(context) and attribute:

--- a/djangocms_frontend/templatetags/frontend.py
+++ b/djangocms_frontend/templatetags/frontend.py
@@ -357,12 +357,19 @@ class InlineField(CMSEditableObject):
             attribute = instance  # First parameter is the attribute
             instance = context.get("instance", None)  # Use instance from context
 
+        # To be editable the instance needs to be a CMSPlugin, not a DummyPlugin (they have no pk in their model class)
+        # Finally, the placeholder needs to allow editing.
+        placeholder_editable = (
+            isinstance(instance, CMSPlugin)
+            and instance.pk
+            and instance.placeholder.check_source(context["request"].user)
+        )
+
         if is_registering_component(context) and attribute:
             # Autodetect inline field and add it to the component
             update_component_properties(context, "frontend_editable_fields", attribute, append=True)
-        elif is_inline_editing_active(context) and isinstance(instance, CMSPlugin) and instance.pk:
-            # Only allow inline field to be rendered if inline editing is active and the instance is a CMSPlugin
-            # DummyPlugins of the ``plugin`` tag are cannot be edited (they have no pk in their model class)
+        elif is_inline_editing_active(context) and placeholder_editable:
+            # Only allow inline field to be rendered if inline editing is active
             kwargs["edit_fields"] = attribute
             return super().render_tag(context, instance=instance, attribute=attribute, **kwargs)
         else:

--- a/tests/test_frontend_templatetags.py
+++ b/tests/test_frontend_templatetags.py
@@ -1,4 +1,5 @@
 import json
+import unittest
 import uuid
 
 from cms.api import add_plugin
@@ -20,7 +21,7 @@ from djangocms_frontend.templatetags.frontend import (
     update_component_properties,
 )
 
-from .fixtures import TestFixture
+from .fixtures import DJANGO_CMS4, TestFixture
 
 
 class GetAttributesTagTestCase(TestCase):
@@ -218,6 +219,36 @@ class UpdateComponentPropertiesTestCase(TestCase):
         update_component_properties(context, "slots", ("SlotPlugin2", "Body"), append=True)
         _, kwargs = context["_cms_components"]["cms_component"][0]
         self.assertEqual(len(kwargs["slots"]), 2)
+
+
+class InlineFieldTestCase(TestFixture, CMSTestCase):
+    """Tests for the inline_field template tag."""
+
+    @unittest.skipUnless(DJANGO_CMS4, "django CMS 4+ required")
+    def test_check_source_called_exactly_once(self):
+        """Regression test: placeholder.check_source must be called exactly once
+        when rendering inline_field, not once per tag evaluation."""
+        from unittest.mock import MagicMock, patch
+
+        parent = add_plugin(
+            placeholder=self.placeholder,
+            plugin_type=AlertPlugin.__name__,
+            language=self.language,
+        )
+        parent.initialize_from_form(AlertForm).save()
+
+        factory = RequestFactory()
+        request = factory.get("/")
+        request.user = self.superuser
+        request.session = SessionStore()
+        request.session["inline_editing"] = True
+
+        tpl = Template('{% load frontend %}{% inline_field instance "alert_context" %}')
+
+        with patch.object(type(self.placeholder), "check_source", return_value=True) as mock_check:
+            tpl.render(Context({"request": request, "instance": parent}))
+
+        mock_check.assert_called_once_with(self.superuser)
 
 
 class ChildPluginsRenderTestCase(TestFixture, CMSTestCase):


### PR DESCRIPTION
## Summary by Sourcery

Ensure inline field template tags respect placeholder editability and add regression coverage for check_source usage.

Bug Fixes:
- Prevent read-only placeholders from rendering inline fields as editable by honoring placeholder.check_source when available.

Tests:
- Add regression test verifying placeholder.check_source is called exactly once when rendering inline_field under django CMS 4.