### PR TITLE
fix: Add space between element attributes into AbstractFrontendUIItem…

### DIFF
--- a/djangocms_frontend/models.py
+++ b/djangocms_frontend/models.py
@@ -81,7 +81,7 @@ class AbstractFrontendUIItem(CMSPlugin):
         else:
             attributes = {}
         classes = self.get_classes()  # get classes
-        classes = (f'class="{classes}"') if classes else ""  # to string
+        classes = f'class="{classes}" ' if classes else ""  # to string
         parts = (
             f'{item}="{conditional_escape(value)}"' if value else f"{item}"
             for item, value in attributes.items()

--- a/tests/test_advanced_settings.py
+++ b/tests/test_advanced_settings.py
@@ -22,8 +22,7 @@ class AdvancedSettingsModelTestCase(TestCase):
         )
         instance.initialize_from_form(AlertForm).save()
         attrs = instance.get_attributes()
-        self.assertIn("data-test", attrs)
-        self.assertIn("custom-class", attrs)
+        self.assertEqual(attrs, ' class="custom-class" data-test="value"')
 
     def test_get_classes_includes_user_classes_by_default(self):
         instance = Alert.objects.create(


### PR DESCRIPTION
Error: No space between attributes.
Description: Adding missing spaces between attributes.

## Summary by Sourcery

Fix attribute string generation so element attributes are separated by spaces.

Bug Fixes:
- Ensure generated HTML attributes include spaces between class and other attributes to avoid concatenation issues.

Tests:
- Update advanced settings attribute test to assert the full, correctly spaced attribute string.