### PR TITLE
feat: Add rename subcommand for renaming ui plugins and components.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build docs
         run: |
           cd docs
-          make html
+          sphinx-build -b html -d _build/doctrees source _build/html
 
   spelling:
     runs-on: ubuntu-latest

--- a/djangocms_frontend/management/commands/frontend.py
+++ b/djangocms_frontend/management/commands/frontend.py
@@ -4,6 +4,7 @@ from .subcommands.base import SubcommandsCommand
 from .subcommands.clear_advanced_settings import ClearAdvancedSettings
 from .subcommands.frequency_analysis import FrequencyAnalysis
 from .subcommands.migrate import Migrate
+from .subcommands.rename import Rename
 from .subcommands.stale_references import StaleReferences
 from .subcommands.sync_permissions import SyncPermissions
 
@@ -14,6 +15,7 @@ class Command(SubcommandsCommand):
         "clear_advanced_settings": ClearAdvancedSettings,
         "migrate": Migrate,
         "frequency_analysis": FrequencyAnalysis,
+        "rename": Rename,
         "stale_references": StaleReferences,
         "sync_permissions": SyncPermissions,
     }

--- a/djangocms_frontend/management/commands/subcommands/rename.py
+++ b/djangocms_frontend/management/commands/subcommands/rename.py
@@ -1,5 +1,6 @@
 from cms.models import CMSPlugin
 from cms.plugin_pool import plugin_pool
+from django.db import transaction
 
 from djangocms_frontend.models import AbstractFrontendUIItem
 
@@ -51,26 +52,27 @@ class Rename(SubcommandsCommand):
                 )
             )
             if options["interactive"]:
-                ok = input("Type 'yes' to continue, or 'no' to cancel: ")
+                ok = input("Type 'yes' to continue, or 'no' to cancel: ").lower()
             else:
                 ok = "yes"
-            if ok != "yes":
+            if ok not in ("yes", "y"):
                 self.stdout.write(self.style.ERROR("Aborted."))
                 return
 
-        # Update plugin_type
-        updated = CMSPlugin.objects.filter(plugin_type=old_plugin).update(plugin_type=new_plugin)
-        self.stdout.write(
-            self.style.SUCCESS(f"Updated {updated} plugins: plugin_type '{old_plugin}' -> '{new_plugin}'")
-        )
-
-        # Update ui_item if the new plugin's model is a subclass of AbstractFrontendUIItem
-        if update_ui_item:
-            new_ui_item = new_plugin_cls.model.__name__
-            ui_updated = (
-                new_plugin_cls.model.objects.filter(plugin_type=new_plugin)
-                .exclude(ui_item=new_ui_item)
-                .update(ui_item=new_ui_item)
+        # Update plugin_type and ui_item atomically
+        with transaction.atomic():
+            updated = CMSPlugin.objects.filter(plugin_type=old_plugin).update(plugin_type=new_plugin)
+            self.stdout.write(
+                self.style.SUCCESS(f"Updated {updated} plugins: plugin_type '{old_plugin}' -> '{new_plugin}'")
             )
-            if ui_updated:
-                self.stdout.write(self.style.SUCCESS(f"Updated {ui_updated} plugins: ui_item -> '{new_ui_item}'"))
+
+            # Update ui_item if the new plugin's model is a subclass of AbstractFrontendUIItem
+            if update_ui_item:
+                new_ui_item = new_plugin_cls.model.__name__
+                ui_updated = (
+                    new_plugin_cls.model.objects.filter(plugin_type=new_plugin)
+                    .exclude(ui_item=new_ui_item)
+                    .update(ui_item=new_ui_item)
+                )
+                if ui_updated:
+                    self.stdout.write(self.style.SUCCESS(f"Updated {ui_updated} plugins: ui_item -> '{new_ui_item}'"))

--- a/djangocms_frontend/management/commands/subcommands/rename.py
+++ b/djangocms_frontend/management/commands/subcommands/rename.py
@@ -1,0 +1,76 @@
+from cms.models import CMSPlugin
+from cms.plugin_pool import plugin_pool
+
+from djangocms_frontend.models import AbstractFrontendUIItem
+
+from .base import SubcommandsCommand
+
+
+class Rename(SubcommandsCommand):
+    help_string = "Renames a plugin type in the database"
+    command_name = "rename"
+
+    def add_arguments(self, parser):
+        parser.add_argument("old_plugin", help="The plugin type to rename (must not be installed but present in db)")
+        parser.add_argument("new_plugin", help="The plugin type to rename to (must be installed)")
+
+    def handle(self, *args, **options):
+        old_plugin = options["old_plugin"]
+        new_plugin = options["new_plugin"]
+
+        # Verify old_plugin is not installed
+        all_plugins = plugin_pool.get_all_plugins()
+        installed_names = {cls.__name__: cls for cls in all_plugins}
+
+        if old_plugin in installed_names:
+            self.stderr.write(self.style.ERROR(f"Plugin '{old_plugin}' is still installed. It must not be installed."))
+            return
+
+        # Verify old_plugin exists in db
+        count = CMSPlugin.objects.filter(plugin_type=old_plugin).count()
+        if count == 0:
+            self.stderr.write(self.style.ERROR(f"Plugin '{old_plugin}' not found in the database."))
+            return
+
+        # Verify new_plugin is installed
+        if new_plugin not in installed_names:
+            self.stderr.write(self.style.ERROR(f"Plugin '{new_plugin}' is not installed."))
+            return
+
+        new_plugin_cls = installed_names[new_plugin]
+        has_model = new_plugin_cls.model is not None
+        update_ui_item = has_model and issubclass(new_plugin_cls.model, AbstractFrontendUIItem)
+
+        # Warn and require confirmation if new plugin has a model but is not an AbstractFrontendUIItem
+        if has_model and not update_ui_item:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"Warning: '{new_plugin}' is not based on AbstractFrontendUIItem. "
+                    "No plugin model instances will be created or migrated. "
+                    "Only the plugin_type field on CMSPlugin will be updated."
+                )
+            )
+            if options["interactive"]:
+                ok = input("Type 'yes' to continue, or 'no' to cancel: ")
+            else:
+                ok = "yes"
+            if ok != "yes":
+                self.stdout.write(self.style.ERROR("Aborted."))
+                return
+
+        # Update plugin_type
+        updated = CMSPlugin.objects.filter(plugin_type=old_plugin).update(plugin_type=new_plugin)
+        self.stdout.write(
+            self.style.SUCCESS(f"Updated {updated} plugins: plugin_type '{old_plugin}' -> '{new_plugin}'")
+        )
+
+        # Update ui_item if the new plugin's model is a subclass of AbstractFrontendUIItem
+        if update_ui_item:
+            new_ui_item = new_plugin_cls.model.__name__
+            ui_updated = (
+                new_plugin_cls.model.objects.filter(plugin_type=new_plugin)
+                .exclude(ui_item=new_ui_item)
+                .update(ui_item=new_ui_item)
+            )
+            if ui_updated:
+                self.stdout.write(self.style.SUCCESS(f"Updated {ui_updated} plugins: ui_item -> '{new_ui_item}'"))

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -56,7 +56,7 @@ help:
 
 install:
 	@echo "... setting up docs virtualenv"
-	python3 -m venv env
+	[ -d env ] || python3 -m venv env
 	. $(VENV); pip install -r requirements.txt
 	@echo "\n" \
 	      "-------------------------------------------------------------------------------------------------- \n" \
@@ -66,12 +66,12 @@ clean:
 	rm -rf $(BUILDDIR)/*
 
 html:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	. $(VENV); $(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 dirhtml:
-	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
+	. $(VENV); $(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 

--- a/docs/source/how-to/index.rst
+++ b/docs/source/how-to/index.rst
@@ -21,4 +21,5 @@ step-by-step guidance.
    create-themes
    migrate-bootstrap4
    migrate-3rd-party-plugins
+   migrate-custom-plugins
    internal-link-targets

--- a/docs/source/how-to/migrate-custom-plugins.rst
+++ b/docs/source/how-to/migrate-custom-plugins.rst
@@ -1,0 +1,136 @@
+.. _how-to-migrate-custom-plugins:
+
+How to write migrations for custom plugins and components
+=========================================================
+
+When you rename, reorganize, or replace custom plugins and components, existing
+plugin instances in the database still reference the old ``plugin_type``. A
+Django data migration lets you update those references so that the CMS can find
+the correct plugin class again.
+
+This guide covers the two most common scenarios:
+
+* Renaming a plugin (changing its class name or moving it to a different app).
+* Replacing one plugin with another.
+
+.. note::
+
+   djangocms-frontend plugins share a single database table
+   (``djangocms_frontend_frontenduiitem``) through proxy models.  This means
+   renaming a plugin does **not** require any schema migration -- only the
+   ``plugin_type`` (and optionally ``ui_item``) fields need to be updated.
+
+
+Using the management command
+----------------------------
+
+For one-off renames that you run manually on each environment, the
+``frontend rename`` management command is the quickest option::
+
+    python -m manage frontend rename OldPlugin NewPlugin
+
+See the :doc:`management commands reference <../reference/management-commands>`
+for details and validation rules.
+
+
+Writing a data migration
+------------------------
+
+If you want the rename to happen automatically when ``manage.py migrate`` is
+run -- for example as part of a deployment pipeline -- wrap it in a Django data
+migration.
+
+Create an empty migration in your app::
+
+    python -m manage makemigrations --empty yourapp -n rename_old_plugin
+
+Then add the rename logic using ``RunPython``:
+
+.. code-block:: python
+
+    from django.db import migrations
+
+
+    def rename_plugin(apps, schema_editor):
+        CMSPlugin = apps.get_model("cms", "CMSPlugin")
+        CMSPlugin.objects.filter(
+            plugin_type="OldPlugin",
+        ).update(plugin_type="NewPlugin")
+
+        # Only needed if the plugin model is based on AbstractFrontendUIItem
+        FrontendUIItem = apps.get_model("djangocms_frontend", "FrontendUIItem")
+        FrontendUIItem.objects.filter(
+            plugin_type="NewPlugin",
+        ).exclude(
+            ui_item="NewModel",
+        ).update(ui_item="NewModel")
+
+
+    def reverse_rename(apps, schema_editor):
+        CMSPlugin = apps.get_model("cms", "CMSPlugin")
+        CMSPlugin.objects.filter(
+            plugin_type="NewPlugin",
+        ).update(plugin_type="OldPlugin")
+
+        FrontendUIItem = apps.get_model("djangocms_frontend", "FrontendUIItem")
+        FrontendUIItem.objects.filter(
+            plugin_type="OldPlugin",
+        ).update(ui_item="OldModel")
+
+
+    class Migration(migrations.Migration):
+        dependencies = [
+            ("yourapp", "0001_initial"),
+            ("djangocms_frontend", "0001_initial"),
+        ]
+
+        operations = [
+            migrations.RunPython(rename_plugin, reverse_rename),
+        ]
+
+Replace ``OldPlugin`` / ``NewPlugin`` with the actual ``plugin_type`` values
+(typically the plugin class name, e.g. ``HeroPlugin``).  Replace ``OldModel`` /
+``NewModel`` with the corresponding model class names (e.g. ``Hero``).
+
+.. tip::
+
+   Always provide a ``reverse_rename`` function so that the migration can be
+   rolled back with ``manage.py migrate yourapp <previous_migration>``.
+
+
+When to update ``ui_item``
+--------------------------
+
+The ``ui_item`` field only exists on models that inherit from
+``AbstractFrontendUIItem`` (including ``FrontendUIItem`` proxy models and custom
+components created with ``CMSFrontendComponent``).  If your plugin uses a
+different model base -- or has no model at all -- skip the ``ui_item`` update.
+
++----------------------------------------------+----------------------------+
+| Plugin base                                  | Update ``ui_item``?        |
++==============================================+============================+
+| ``FrontendUIItem`` (proxy model)             | Yes                        |
++----------------------------------------------+----------------------------+
+| ``AbstractFrontendUIItem`` (concrete model)  | Yes                        |
++----------------------------------------------+----------------------------+
+| ``CMSFrontendComponent``                     | Yes                        |
++----------------------------------------------+----------------------------+
+| ``CMSPluginBase`` with a custom model        | No                         |
++----------------------------------------------+----------------------------+
+| Plugin with ``model = None``                 | No                         |
++----------------------------------------------+----------------------------+
+
+
+Combining with schema migrations
+---------------------------------
+
+If your rename also involves schema changes (e.g. moving from a proxy model to
+a concrete model with extra fields), put the data migration **between** the
+schema migrations:
+
+1. Schema migration that creates the new table or fields.
+2. Data migration that copies/renames plugin instances.
+3. Schema migration that removes the old table or fields (if any).
+
+This ensures the data migration can read from the old structure and write to the
+new one.

--- a/docs/source/how-to/migrate-custom-plugins.rst
+++ b/docs/source/how-to/migrate-custom-plugins.rst
@@ -98,29 +98,6 @@ Replace ``OldPlugin`` / ``NewPlugin`` with the actual ``plugin_type`` values
    rolled back with ``manage.py migrate yourapp <previous_migration>``.
 
 
-When to update ``ui_item``
---------------------------
-
-The ``ui_item`` field only exists on models that inherit from
-``AbstractFrontendUIItem`` (including ``FrontendUIItem`` proxy models and custom
-components created with ``CMSFrontendComponent``).  If your plugin uses a
-different model base -- or has no model at all -- skip the ``ui_item`` update.
-
-+----------------------------------------------+----------------------------+
-| Plugin base                                  | Update ``ui_item``?        |
-+==============================================+============================+
-| ``FrontendUIItem`` (proxy model)             | Yes                        |
-+----------------------------------------------+----------------------------+
-| ``AbstractFrontendUIItem`` (concrete model)  | Yes                        |
-+----------------------------------------------+----------------------------+
-| ``CMSFrontendComponent``                     | Yes                        |
-+----------------------------------------------+----------------------------+
-| ``CMSPluginBase`` with a custom model        | No                         |
-+----------------------------------------------+----------------------------+
-| Plugin with ``model = None``                 | No                         |
-+----------------------------------------------+----------------------------+
-
-
 Combining with schema migrations
 ---------------------------------
 

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -807,6 +807,24 @@ project directory. ``command`` can be one of the following:
     plugins. This way you can set permissions for all plugins by setting them
     for ``FrontendUIItem`` and then syncing them.
 
+``rename``
+    Renames a plugin type in the database. This is useful when a plugin has been
+    replaced by a new one and existing instances need to be reassigned.
+
+    It takes two positional arguments:
+
+    - ``old_plugin``: The plugin type to rename. Must **not** be installed but
+      must still be present in the database.
+    - ``new_plugin``: The plugin type to rename to. Must be installed.
+
+    The command updates the ``plugin_type`` field on all matching ``CMSPlugin``
+    rows. If the new plugin's model is a subclass of ``AbstractFrontendUIItem``,
+    the ``ui_item`` field is updated as well.
+
+    Example::
+
+        python -m manage frontend rename OldCardPlugin CardPlugin
+
 
 *************
 Running Tests

--- a/docs/source/reference/management-commands.rst
+++ b/docs/source/reference/management-commands.rst
@@ -50,3 +50,24 @@ project directory. ``command`` can be one of the following:
     Run with ``--noinput`` to skip the confirmation prompt::
 
         python -m manage frontend clear_advanced_settings --noinput
+
+``rename``
+    Renames a plugin type in the database. This is useful when a plugin has been
+    replaced by a new one and existing instances need to be reassigned. This comand
+    is intended for djangocms-frontend plugins which share the same plugin model
+    (:class:`AbstractFrontendUIItem`). Hence, model instances are not created, so only
+    apply this command to non-frontend plugins if you know what you're doing.
+
+    It takes two positional arguments:
+
+    - ``old_plugin``: The plugin type to rename. Must **not** be installed but
+      must still be present in the database.
+    - ``new_plugin``: The plugin type to rename to. Must be installed.
+
+    The command updates the ``plugin_type`` field on all matching ``CMSPlugin``
+    rows. If the new plugin's model is a subclass of ``AbstractFrontendUIItem``,
+    the ``ui_item`` field is updated as well.
+
+    Example::
+
+        python -m manage frontend rename OldCardPlugin CardPlugin

--- a/docs/source/reference/management-commands.rst
+++ b/docs/source/reference/management-commands.rst
@@ -55,7 +55,7 @@ project directory. ``command`` can be one of the following:
     Renames a plugin type in the database. This is useful when a plugin has been
     replaced by a new one and existing instances need to be reassigned. This comand
     is intended for djangocms-frontend plugins which share the same plugin model
-    (:class:`AbstractFrontendUIItem`). Hence, model instances are not created, so only
+    (:class:`FrontendUIItem`). Hence, model instances are not created, so only
     apply this command to non-frontend plugins if you know what you're doing.
 
     It takes two positional arguments:
@@ -65,7 +65,7 @@ project directory. ``command`` can be one of the following:
     - ``new_plugin``: The plugin type to rename to. Must be installed.
 
     The command updates the ``plugin_type`` field on all matching ``CMSPlugin``
-    rows. If the new plugin's model is a subclass of ``AbstractFrontendUIItem``,
+    rows. If the new plugin's model is a subclass of :class:`FrontendUIItem`,
     the ``ui_item`` field is updated as well.
 
     Example::

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -134,8 +134,30 @@ class RenameCommandTestCase(TestCase):
         self.assertEqual(instance.plugin_type, "OldTextPlugin")
 
     @patch("builtins.input", return_value="yes")
-    def test_proceeds_when_user_confirms_non_frontend_rename(self, mock_input):
-        """Renaming to a non-AbstractFrontendUIItem plugin proceeds if user confirms."""
+    def test_proceeds_when_user_confirms_with_yes(self, mock_input):
+        """Renaming to a non-AbstractFrontendUIItem plugin proceeds if user types 'yes'."""
+        instance = CMSPlugin.objects.create(plugin_type="OldTextPlugin")
+
+        out, _ = self._call_rename("OldTextPlugin", "TextPlugin")
+
+        self.assertIn("Updated 1 plugins", out)
+        instance.refresh_from_db()
+        self.assertEqual(instance.plugin_type, "TextPlugin")
+
+    @patch("builtins.input", return_value="y")
+    def test_proceeds_when_user_confirms_with_y(self, mock_input):
+        """Renaming to a non-AbstractFrontendUIItem plugin proceeds if user types 'y'."""
+        instance = CMSPlugin.objects.create(plugin_type="OldTextPlugin")
+
+        out, _ = self._call_rename("OldTextPlugin", "TextPlugin")
+
+        self.assertIn("Updated 1 plugins", out)
+        instance.refresh_from_db()
+        self.assertEqual(instance.plugin_type, "TextPlugin")
+
+    @patch("builtins.input", return_value="YES")
+    def test_confirmation_is_case_insensitive(self, mock_input):
+        """Confirmation input is case-insensitive."""
         instance = CMSPlugin.objects.create(plugin_type="OldTextPlugin")
 
         out, _ = self._call_rename("OldTextPlugin", "TextPlugin")

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -1,0 +1,173 @@
+from io import StringIO
+from unittest.mock import patch
+
+from cms.models import CMSPlugin
+from django.core.management import call_command
+from django.test import TestCase
+
+from djangocms_frontend.contrib.alert.models import Alert
+
+
+class RenameCommandTestCase(TestCase):
+    """Tests for the frontend rename management command."""
+
+    def _call_rename(self, old, new, **kwargs):
+        out = StringIO()
+        err = StringIO()
+        call_command("frontend", "rename", old, new, stdout=out, stderr=err, **kwargs)
+        return out.getvalue(), err.getvalue()
+
+    def test_rename_updates_plugin_type(self):
+        """Renaming updates plugin_type on all matching CMSPlugin rows."""
+        instance = Alert.objects.create(
+            config=dict(alert_context="primary"),
+        )
+        # Simulate an old, uninstalled plugin type
+        CMSPlugin.objects.filter(pk=instance.pk).update(plugin_type="OldAlertPlugin")
+
+        out, err = self._call_rename("OldAlertPlugin", "AlertPlugin")
+
+        instance.refresh_from_db()
+        self.assertEqual(instance.plugin_type, "AlertPlugin")
+        self.assertIn("Updated", out)
+        self.assertEqual(err, "")
+
+    def test_rename_updates_ui_item(self):
+        """If new plugin model is an AbstractFrontendUIItem subclass, ui_item is updated."""
+        instance = Alert.objects.create(
+            config=dict(alert_context="primary"),
+        )
+        CMSPlugin.objects.filter(pk=instance.pk).update(plugin_type="OldAlertPlugin")
+        Alert.objects.filter(pk=instance.pk).update(ui_item="OldAlert")
+
+        out, _ = self._call_rename("OldAlertPlugin", "AlertPlugin")
+
+        instance.refresh_from_db()
+        self.assertEqual(instance.ui_item, "Alert")
+        self.assertIn("ui_item", out)
+
+    def test_rename_does_not_touch_other_plugins(self):
+        """Only plugins with the old plugin_type are affected."""
+        instance1 = Alert.objects.create(config=dict(alert_context="primary"))
+        instance2 = Alert.objects.create(config=dict(alert_context="danger"))
+        CMSPlugin.objects.filter(pk=instance1.pk).update(plugin_type="OldAlertPlugin")
+        CMSPlugin.objects.filter(pk=instance2.pk).update(plugin_type="AlertPlugin")
+
+        self._call_rename("OldAlertPlugin", "AlertPlugin")
+
+        instance1.refresh_from_db()
+        instance2.refresh_from_db()
+        self.assertEqual(instance1.plugin_type, "AlertPlugin")
+        self.assertEqual(instance2.plugin_type, "AlertPlugin")
+        # Only 1 was renamed, not 2
+        self.assertEqual(instance2.config["alert_context"], "danger")
+
+    def test_rename_multiple_plugins(self):
+        """All instances with the old plugin_type are renamed."""
+        instances = [Alert.objects.create(config=dict(alert_context="primary")) for _ in range(3)]
+        pks = [i.pk for i in instances]
+        CMSPlugin.objects.filter(pk__in=pks).update(plugin_type="OldAlertPlugin")
+
+        out, _ = self._call_rename("OldAlertPlugin", "AlertPlugin")
+
+        for pk in pks:
+            self.assertEqual(CMSPlugin.objects.get(pk=pk).plugin_type, "AlertPlugin")
+        self.assertIn("Updated 3 plugins", out)
+
+    def test_error_old_plugin_still_installed(self):
+        """Renaming fails if old_plugin is still installed."""
+        Alert.objects.create(config=dict(alert_context="primary"))
+
+        _, err = self._call_rename("AlertPlugin", "AlertPlugin")
+
+        self.assertIn("still installed", err)
+
+    def test_error_old_plugin_not_in_db(self):
+        """Renaming fails if old_plugin has no rows in the database."""
+        _, err = self._call_rename("GhostPlugin", "AlertPlugin")
+
+        self.assertIn("not found in the database", err)
+
+    def test_error_new_plugin_not_installed(self):
+        """Renaming fails if new_plugin is not installed."""
+        instance = Alert.objects.create(config=dict(alert_context="primary"))
+        CMSPlugin.objects.filter(pk=instance.pk).update(plugin_type="OldAlertPlugin")
+
+        _, err = self._call_rename("OldAlertPlugin", "NonExistentPlugin")
+
+        self.assertIn("not installed", err)
+        # Verify nothing changed
+        instance.refresh_from_db()
+        self.assertEqual(instance.plugin_type, "OldAlertPlugin")
+
+    def test_ui_item_not_updated_when_already_correct(self):
+        """No ui_item update is reported when ui_item already matches."""
+        instance = Alert.objects.create(config=dict(alert_context="primary"))
+        # ui_item is "Alert" by default (set in save()), plugin_type is "AlertPlugin"
+        CMSPlugin.objects.filter(pk=instance.pk).update(plugin_type="OldAlertPlugin")
+        # ui_item is already "Alert" which matches the new plugin's model name
+
+        out, _ = self._call_rename("OldAlertPlugin", "AlertPlugin")
+
+        self.assertIn("Updated 1 plugins", out)
+        self.assertNotIn("ui_item", out)
+
+    def test_warning_for_non_frontend_plugin(self):
+        """A warning is shown when renaming to a non-AbstractFrontendUIItem plugin."""
+        CMSPlugin.objects.create(plugin_type="OldTextPlugin")
+
+        out, _ = self._call_rename("OldTextPlugin", "TextPlugin", interactive=False)
+
+        self.assertIn("not based on AbstractFrontendUIItem", out)
+        self.assertIn("Updated 1 plugins", out)
+
+    @patch("builtins.input", return_value="no")
+    def test_aborts_when_user_declines_non_frontend_rename(self, mock_input):
+        """Renaming to a non-AbstractFrontendUIItem plugin aborts if user declines."""
+        instance = CMSPlugin.objects.create(plugin_type="OldTextPlugin")
+
+        out, _ = self._call_rename("OldTextPlugin", "TextPlugin")
+
+        self.assertIn("not based on AbstractFrontendUIItem", out)
+        self.assertIn("Aborted", out)
+        instance.refresh_from_db()
+        self.assertEqual(instance.plugin_type, "OldTextPlugin")
+
+    @patch("builtins.input", return_value="yes")
+    def test_proceeds_when_user_confirms_non_frontend_rename(self, mock_input):
+        """Renaming to a non-AbstractFrontendUIItem plugin proceeds if user confirms."""
+        instance = CMSPlugin.objects.create(plugin_type="OldTextPlugin")
+
+        out, _ = self._call_rename("OldTextPlugin", "TextPlugin")
+
+        self.assertIn("Updated 1 plugins", out)
+        instance.refresh_from_db()
+        self.assertEqual(instance.plugin_type, "TextPlugin")
+
+    def test_no_warning_for_frontend_plugin(self):
+        """No warning is shown when renaming to an AbstractFrontendUIItem plugin."""
+        instance = Alert.objects.create(config=dict(alert_context="primary"))
+        CMSPlugin.objects.filter(pk=instance.pk).update(plugin_type="OldAlertPlugin")
+
+        out, _ = self._call_rename("OldAlertPlugin", "AlertPlugin")
+
+        self.assertNotIn("not based on AbstractFrontendUIItem", out)
+        self.assertIn("Updated 1 plugins", out)
+
+    @patch(
+        "djangocms_frontend.management.commands.subcommands.rename.plugin_pool.get_all_plugins",
+    )
+    def test_rename_to_plugin_with_no_model(self, mock_get_all):
+        """Renaming to a plugin with model=None works without warning or confirmation."""
+        # Create a fake plugin class with no model
+        fake_plugin = type("NoModelPlugin", (), {"__name__": "NoModelPlugin", "model": None})
+        mock_get_all.return_value = [fake_plugin]
+
+        CMSPlugin.objects.create(plugin_type="OldPlugin")
+
+        out, _ = self._call_rename("OldPlugin", "NoModelPlugin")
+
+        self.assertNotIn("not based on AbstractFrontendUIItem", out)
+        self.assertNotIn("Aborted", out)
+        self.assertIn("Updated 1 plugins", out)
+        self.assertNotIn("ui_item", out)


### PR DESCRIPTION
## Summary by Sourcery

Add a management subcommand to rename CMS plugin types in the database and update related frontend UI items, with accompanying tests and documentation stubs.

New Features:
- Introduce a `frontend rename` management subcommand for renaming CMS plugin types to a new installed plugin type, with optional updating of associated UI items.

Documentation:
- Add reference entry and how-to stub documentation for the new `frontend rename` management command.

Tests:
- Add unit tests covering successful plugin renames, UI item updates, error conditions, and interactive confirmation behavior for the new rename subcommand.