### PR TITLE
fix: Forms did not validate if advanced settings had been disabled

### DIFF
--- a/djangocms_frontend/common/attributes.py
+++ b/djangocms_frontend/common/attributes.py
@@ -32,12 +32,19 @@ class AttributesMixin:
         )
 
 
-class AttributesFormMixin(EntangledModelFormMixin):
-    class Meta:
-        entangled_fields = {
-            "config": [
-                "attributes",
-            ]
-        }
+if SHOW_ADVANCED_SETTINGS:
 
-    attributes = AttributesFormField()
+    class AttributesFormMixin(EntangledModelFormMixin):
+        class Meta:
+            entangled_fields = {
+                "config": [
+                    "attributes",
+                ]
+            }
+
+        attributes = AttributesFormField()
+
+else:
+
+    class AttributesFormMixin:
+        pass

--- a/djangocms_frontend/models.py
+++ b/djangocms_frontend/models.py
@@ -50,23 +50,7 @@ class AbstractFrontendUIItem(CMSPlugin):
         self.html_id: str | None = None  # HTML id attribute will be set in template tag set_html_id.
         super().__init__(*args, **kwargs)
         if not SHOW_ADVANCED_SETTINGS:
-            self.tag_type = self._get_tag_type_initial()
-
-    def _get_tag_type_initial(self):
-        default = self._meta.get_field("tag_type").default
-        try:
-            plugin_class = self.get_plugin_class()
-            form = getattr(plugin_class, "form", None)
-            if form is not None and hasattr(form, "base_fields") and "tag_type" in form.base_fields:
-                tag_field = form.base_fields["tag_type"]
-                initial = getattr(tag_field, "initial", None)
-                if callable(initial):
-                    initial = initial()
-                return default if initial is None else initial
-        except Exception:  # pragma: no cover
-            pass
-        return default
-
+           self.tag_type = self._meta.get_field("tag_type").default
     def __getattr__(self, item):
         """Makes properties of plugin config available as plugin properties."""
         if item[0] != "_" and item in self.config:  # Avoid infinite recursion trying to get .config from db

--- a/djangocms_frontend/models.py
+++ b/djangocms_frontend/models.py
@@ -50,7 +50,18 @@ class AbstractFrontendUIItem(CMSPlugin):
         self.html_id: str | None = None  # HTML id attribute will be set in template tag set_html_id.
         super().__init__(*args, **kwargs)
         if not SHOW_ADVANCED_SETTINGS:
-            self.tag_type = self._meta.get_field("tag_type").default
+            self.tag_type = self._get_tag_type_initial()
+
+    def _get_tag_type_initial(self):
+        default = self._meta.get_field("tag_type").default
+        try:
+            plugin_class = self.get_plugin_class()
+            form = getattr(plugin_class, "form", None)
+            if form is not None and hasattr(form, "base_fields") and "tag_type" in form.base_fields:
+                return form.base_fields["tag_type"].initial or default
+        except Exception:  # pragma: no cover
+            pass
+        return default
 
     def __getattr__(self, item):
         """Makes properties of plugin config available as plugin properties."""

--- a/djangocms_frontend/models.py
+++ b/djangocms_frontend/models.py
@@ -50,7 +50,8 @@ class AbstractFrontendUIItem(CMSPlugin):
         self.html_id: str | None = None  # HTML id attribute will be set in template tag set_html_id.
         super().__init__(*args, **kwargs)
         if not SHOW_ADVANCED_SETTINGS:
-           self.tag_type = self._meta.get_field("tag_type").default
+            self.tag_type = self._meta.get_field("tag_type").default
+
     def __getattr__(self, item):
         """Makes properties of plugin config available as plugin properties."""
         if item[0] != "_" and item in self.config:  # Avoid infinite recursion trying to get .config from db

--- a/djangocms_frontend/models.py
+++ b/djangocms_frontend/models.py
@@ -58,7 +58,11 @@ class AbstractFrontendUIItem(CMSPlugin):
             plugin_class = self.get_plugin_class()
             form = getattr(plugin_class, "form", None)
             if form is not None and hasattr(form, "base_fields") and "tag_type" in form.base_fields:
-                return form.base_fields["tag_type"].initial or default
+                tag_field = form.base_fields["tag_type"]
+                initial = getattr(tag_field, "initial", None)
+                if callable(initial):
+                    initial = initial()
+                return default if initial is None else initial
         except Exception:  # pragma: no cover
             pass
         return default

--- a/tests/test_advanced_settings.py
+++ b/tests/test_advanced_settings.py
@@ -5,10 +5,12 @@ from cms.api import add_plugin
 from cms.test_utils.testcases import CMSTestCase
 from django.core.management import call_command
 from django.test import TestCase
+from django.test.client import RequestFactory
 
 from djangocms_frontend.contrib.alert.cms_plugins import AlertPlugin
 from djangocms_frontend.contrib.alert.forms import AlertForm
 from djangocms_frontend.contrib.alert.models import Alert
+from djangocms_frontend.settings import DEVICE_CHOICES
 
 from .fixtures import TestFixture
 
@@ -66,12 +68,35 @@ class AdvancedSettingsModelTestCase(TestCase):
     def test_tag_type_reset_to_default_when_disabled(self):
         instance = Alert.objects.create(tag_type="section")
         instance.initialize_from_form(AlertForm).save()
-        self.assertEqual(instance.tag_type, "div")
+        self.assertEqual(instance.tag_type, AlertForm.base_fields["tag_type"].initial)
 
     def test_tag_type_preserved_when_enabled(self):
         instance = Alert.objects.create(tag_type="section")
         instance.initialize_from_form(AlertForm).save()
         self.assertEqual(instance.tag_type, "section")
+
+    def test_change_form_submit_uses_default_tag_type_when_disabled(self):
+        instance = Alert.objects.create(tag_type="section")
+        instance.initialize_from_form(AlertForm).save()
+        self.assertEqual(instance.tag_type, "section")
+
+        with patch("djangocms_frontend.models.SHOW_ADVANCED_SETTINGS", False):
+            plugin = Alert.objects.get(pk=instance.pk)
+            request = RequestFactory().post("/")
+            form_class = AlertPlugin().get_form(request, obj=plugin, change=True)
+            form = form_class(
+                data={
+                    "alert_context": plugin.config.get("alert_context", "primary"),
+                    "margin_devices": [size for size, _ in DEVICE_CHOICES],
+                    "padding_devices": [size for size, _ in DEVICE_CHOICES],
+                },
+                instance=plugin,
+            )
+
+            self.assertTrue(form.is_valid(), form.errors)
+            updated = form.save()
+
+        self.assertEqual(updated.tag_type, AlertForm.base_fields["tag_type"].initial)
 
 
 class AdvancedSettingsFieldsetTestCase(TestFixture, CMSTestCase):


### PR DESCRIPTION
## Summary by Sourcery

Ensure plugins initialize and validate correctly when advanced settings are disabled.

Bug Fixes:
- Avoid form validation errors by omitting attributes configuration when advanced settings are turned off.
- Initialize plugin tag_type from the form field's initial value when advanced settings are disabled instead of always using the model default.

Tests:
- Extend advanced settings tests to cover tag_type initialization and form submission behavior when advanced settings are disabled.