### PR TITLE
fix: Default configs of shared mixins leaked into other plugins

### DIFF
--- a/djangocms_frontend/ui_plugin_base.py
+++ b/djangocms_frontend/ui_plugin_base.py
@@ -1,4 +1,6 @@
 # Import the components from the current directory's models module
+import copy
+
 from cms.plugin_base import CMSPluginBase
 from django.utils.encoding import force_str
 
@@ -44,6 +46,7 @@ class CMSUIPluginBase(FrontendEditableAdminMixin, CMSPluginBase):
             return form_cls
         for field_name, value in defaults.items():
             if field_name in form_cls.base_fields:
+                form_cls.base_fields[field_name] = copy.deepcopy(form_cls.base_fields[field_name])
                 form_cls.base_fields[field_name].initial = value
         return form_cls
 

--- a/tests/grid/test_models.py
+++ b/tests/grid/test_models.py
@@ -154,6 +154,26 @@ class GetFormDefaultsTestCase(TestCase):
             else:
                 del GridContainer.default_config
 
+    def test_default_config_does_not_leak_to_other_plugins(self):
+        """Regression: setting default_config on one plugin must not affect other plugins
+        sharing the same form field instances (e.g. SpacingFormMixin fields)."""
+        from djangocms_frontend.contrib.link.cms_plugins import TextLinkPlugin
+
+        # Set a default_config on GridContainer that affects a shared field
+        original = getattr(GridContainer, "default_config", {})
+        try:
+            GridContainer.default_config = {"padding_y": "py-6"}
+            # Trigger get_form on GridContainer to apply the default
+            self._get_form_instance(GridContainerPlugin)
+            # Now get the Link form — padding_y should NOT have the GridContainer default
+            link_form = self._get_form_instance(TextLinkPlugin)
+            self.assertNotEqual(link_form.fields["padding_y"].initial, "py-6")
+        finally:
+            if original:
+                GridContainer.default_config = original
+            else:
+                del GridContainer.default_config
+
     def test_change_form_does_not_override_initials(self):
         """On edit (change=True), defaults should NOT be applied."""
         original = getattr(GridContainer, "default_config", {})


### PR DESCRIPTION
## Summary by Sourcery

Prevent plugin default configuration from leaking between plugins that share form field instances.

Bug Fixes:
- Ensure default_config values applied in get_form do not mutate shared form field instances across different plugins.

Tests:
- Add a regression test verifying that setting default_config on one plugin does not affect shared form fields in other plugins.