### PR TITLE
fix: Let icon have <i> as default tag (w/o advanced settings)

### DIFF
--- a/djangocms_frontend/contrib/icon/models.py
+++ b/djangocms_frontend/contrib/icon/models.py
@@ -1,6 +1,9 @@
 from django.utils.translation import gettext_lazy as _
 
+from djangocms_frontend.helpers import first_choice
 from djangocms_frontend.models import FrontendUIItem
+
+from .conf import ICON_TAG_TYPES
 
 
 class Icon(FrontendUIItem):
@@ -12,6 +15,8 @@ class Icon(FrontendUIItem):
     class Meta:
         proxy = True
         verbose_name = _("Icon")
+
+    default_tag_type = first_choice(ICON_TAG_TYPES)
 
     def get_short_description(self):
         return self.config.get("icon", {}).get("iconClass", _("undefined"))

--- a/djangocms_frontend/models.py
+++ b/djangocms_frontend/models.py
@@ -75,11 +75,6 @@ class AbstractFrontendUIItem(CMSPlugin):
         attrs.update({attr: value})
         self.config["attributes"] = attrs
 
-    def get_tag_type(self):
-        if SHOW_ADVANCED_SETTINGS:
-            return self.tag_type
-        return self._meta.get_field("tag_type").default
-
     def get_attributes(self):
         if SHOW_ADVANCED_SETTINGS:
             attributes = self.config.get("attributes", {})

--- a/djangocms_frontend/models.py
+++ b/djangocms_frontend/models.py
@@ -50,7 +50,7 @@ class AbstractFrontendUIItem(CMSPlugin):
         self.html_id: str | None = None  # HTML id attribute will be set in template tag set_html_id.
         super().__init__(*args, **kwargs)
         if not SHOW_ADVANCED_SETTINGS:
-            self.tag_type = self._meta.get_field("tag_type").default
+            self.tag_type = getattr(self, "default_tag_type", self._meta.get_field("tag_type").default)
 
     def __getattr__(self, item):
         """Makes properties of plugin config available as plugin properties."""
@@ -74,6 +74,11 @@ class AbstractFrontendUIItem(CMSPlugin):
             value += attrs[attr]
         attrs.update({attr: value})
         self.config["attributes"] = attrs
+
+    def get_tag_type(self):
+        if SHOW_ADVANCED_SETTINGS:
+            return self.tag_type
+        return self._meta.get_field("tag_type").default
 
     def get_attributes(self):
         if SHOW_ADVANCED_SETTINGS:

--- a/tests/test_advanced_settings.py
+++ b/tests/test_advanced_settings.py
@@ -10,6 +10,8 @@ from django.test.client import RequestFactory
 from djangocms_frontend.contrib.alert.cms_plugins import AlertPlugin
 from djangocms_frontend.contrib.alert.forms import AlertForm
 from djangocms_frontend.contrib.alert.models import Alert
+from djangocms_frontend.contrib.icon.models import Icon
+from djangocms_frontend.helpers import first_choice
 from djangocms_frontend.settings import DEVICE_CHOICES
 
 from .fixtures import TestFixture
@@ -69,6 +71,14 @@ class AdvancedSettingsModelTestCase(TestCase):
         instance = Alert.objects.create(tag_type="section")
         instance.initialize_from_form(AlertForm).save()
         self.assertEqual(instance.tag_type, AlertForm.base_fields["tag_type"].initial)
+
+    @patch("djangocms_frontend.models.SHOW_ADVANCED_SETTINGS", False)
+    def test_icon_tag_type_uses_icon_default_when_disabled(self):
+        """Icon plugin should use its own default_tag_type ('i'), not the global default ('div')."""
+        from djangocms_frontend.contrib.icon.conf import ICON_TAG_TYPES
+
+        instance = Icon.objects.create()
+        self.assertEqual(instance.tag_type, first_choice(ICON_TAG_TYPES))
 
     def test_tag_type_preserved_when_enabled(self):
         instance = Alert.objects.create(tag_type="section")


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix icon plugins not defaulting to the intended <i> tag when advanced settings are hidden.