### PR TITLE
docs: Add tests for code examples in the docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -109,6 +109,14 @@ exclude_patterns = ["_build"]
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "sphinx"
 
+# Register a "template" highlighting language. ``.. code-block:: template`` is
+# used to mark runnable ``{% plugin %}`` examples that are verified by
+# ``tests/test_doc_examples.py``. It highlights as a Django template.
+from pygments.lexers.templates import HtmlDjangoLexer  # noqa: E402
+from sphinx.highlighting import lexers  # noqa: E402
+
+lexers["template"] = HtmlDjangoLexer()
+
 # A list of ignored prefixes for module index sorting.
 # modindex_common_prefix = []
 

--- a/docs/source/how-to/use-frontend-as-component.rst
+++ b/docs/source/how-to/use-frontend-as-component.rst
@@ -36,10 +36,10 @@ repetition.
 To use a frontend plugin in a template you need to load the ``frontend`` tags
 and then use the ``plugin`` template tag to render a frontend plugin.
 
-.. code::
+.. code-block:: template
 
     {% load frontend %}
-    {% plugin "alert" alert_context="secondary" alert_dismissable=True %}
+    {% plugin "alert" alert_context="secondary" alert_dismissible=True %}
         Here goes the content of the alert.
     {% endplugin %}
 
@@ -49,7 +49,9 @@ You can override these settings by passing them as keyword arguments to the
 
 You can also create more complex reusable components, like a card with inner
 elements such as headers, bodies, and lists, by nesting plugins. Here’s an
-example of a card component::
+example of a card component:
+
+.. code-block:: template
 
     {% load frontend %}
     {% plugin "card" card_alignment="center" card_outline="info" card_text_color="primary" card_full_height=True %}

--- a/docs/source/plugins/components.rst
+++ b/docs/source/plugins/components.rst
@@ -738,7 +738,7 @@ skipped they fall back to their defaults):
 .. note::
 
     Tab items read settings from their parent tab while rendering, so tabs have
-    to be built inside django CMS. Unlike the other components they cannot be
+    to be built inside django CMS. Unlike the other components, they cannot be
     rendered standalone with the ``{% plugin %}`` tag.
 
 .. code-block:: django

--- a/docs/source/plugins/components.rst
+++ b/docs/source/plugins/components.rst
@@ -273,7 +273,7 @@ skipped they fall back to their defaults):
 
     Carousel slides read settings from their parent carousel while rendering,
     so a carousel has to be built inside django CMS. Unlike the other
-    components it cannot be rendered standalone with the ``{% plugin %}`` tag.
+    components, it cannot be rendered standalone with the ``{% plugin %}`` tag.
 
 .. code-block:: django
 

--- a/docs/source/plugins/components.rst
+++ b/docs/source/plugins/components.rst
@@ -427,7 +427,14 @@ Re-usable component example
 used in all your project's templates. Example (if key word arguments are
 skipped they fall back to their defaults):
 
-.. code-block:: template
+.. note::
+
+    The link field depends on the configured link backend. The example below
+    uses the default ``link`` field (via the ``to_link`` filter). If
+    ``djangocms-url-manager`` is installed, links are set through ``url_grouper``
+    and ``site`` instead.
+
+.. code-block:: django
 
     {% load frontend djangocms_link_tags %}
     {% plugin "textlink" link="/about/"|to_link link_type="btn" link_context="primary" link_outline=False %}
@@ -953,7 +960,7 @@ skipped they fall back to their defaults):
 .. note::
 
     The navigation builds a menu from the current request, so it has to be
-    rendered within a django CMS page request. Unlike the other components it
+    rendered within a django CMS page request. Unlike the other components, it
     cannot be rendered standalone with the ``{% plugin %}`` tag.
 
 .. code-block:: django

--- a/docs/source/plugins/components.rst
+++ b/docs/source/plugins/components.rst
@@ -48,7 +48,7 @@ The accordion component is a good example of a re-usable component. It can be
 used in all your project's templates. Here is an example of how to create an
 accordion (if key word arguments are skipped they fall back to their defaults):
 
-.. code-block::
+.. code-block:: template
 
     {% load frontend %}
     {% plugin "accordion" accordion_header_type="h2" accordion_flush=False %}
@@ -96,7 +96,7 @@ Re-usable component example
 used in all your project's templates. Example (if key word arguments are
 skipped they fall back to their defaults):
 
-.. code-block::
+.. code-block:: template
 
     {% load frontend %}
     {% plugin "alert" alert_context="primary" alert_dismissible=True %}
@@ -130,7 +130,7 @@ Re-usable component example
 used in all your project's templates. Example (if key word arguments are
 skipped they fall back to their defaults):
 
-.. code-block::
+.. code-block:: template
 
     {% load frontend %}
     {% plugin "badge" badge_text="My badge" badge_context="info" badge_pills=False %}
@@ -221,11 +221,10 @@ Re-usable component example
 used in all your project's templates. Example (if key word arguments are
 skipped they fall back to their defaults):
 
-.. code-block::
+.. code-block:: template
 
     {% load frontend %}
-    {% plugin "card" card_alignment="center" card_outline="info"
-                     card_text_color="primary" card_full_height=True %}
+    {% plugin "card" card_alignment="center" card_outline="info" card_text_color="primary" card_full_height=True %}
         {% plugin "cardinner" inner_type="card-header" text_alignment="start" %}
             <h4>Card title</h4>
         {% endplugin %}
@@ -270,7 +269,13 @@ Re-usable component example
 used in all your project's templates. Example (if key word arguments are
 skipped they fall back to their defaults):
 
-.. code-block::
+.. note::
+
+    Carousel slides read settings from their parent carousel while rendering,
+    so a carousel has to be built inside django CMS. Unlike the other
+    components it cannot be rendered standalone with the ``{% plugin %}`` tag.
+
+.. code-block:: django
 
     {% load frontend %}
     {% plugin "carousel" template="my_template" carousel_controls=True %}
@@ -331,7 +336,7 @@ Re-usable component example
 used in all your project's templates. Example (if key word arguments are
 skipped they fall back to their defaults):
 
-.. code-block::
+.. code-block:: template
 
     {% load frontend %}
     {% plugin "collapse" %}
@@ -381,7 +386,7 @@ Re-usable component example
 used in all your project's templates. Example (if key word arguments are
 skipped they fall back to their defaults):
 
-.. code-block::
+.. code-block:: template
 
     {% load frontend %}
     {% plugin "jumbotron" jumbotron_fluid=False %}
@@ -422,11 +427,10 @@ Re-usable component example
 used in all your project's templates. Example (if key word arguments are
 skipped they fall back to their defaults):
 
-.. code-block::
+.. code-block:: template
 
-    {% load frontend %}
-    {% url 'some_view' as some_view %}
-    {% plugin "textlink" external_link=some_view link_type="btn" link_context="primary" link_outline=False %}
+    {% load frontend djangocms_link_tags %}
+    {% plugin "textlink" link="/about/"|to_link link_type="btn" link_context="primary" link_outline=False %}
         Click me!
     {% endplugin %}
 
@@ -473,7 +477,7 @@ Re-usable component example
 used in all your project's templates. Example (if key word arguments are
 skipped they fall back to their defaults):
 
-.. code-block::
+.. code-block:: template
 
     {% load frontend %}
     {% plugin "listgroup" list_group_flush=False %}
@@ -512,7 +516,7 @@ Re-usable component example
 used in all your project's templates. Neither the Media nor the Media Body
 plugin take component-specific parameters:
 
-.. code-block::
+.. code-block:: template
 
     {% load frontend %}
     {% plugin "media" %}
@@ -578,7 +582,7 @@ Re-usable component example
 used in all your project's templates. Example (if key word arguments are
 skipped they fall back to their defaults):
 
-.. code-block::
+.. code-block:: template
 
     {% load frontend %}
     {% plugin "spacing" space_property="m" space_sides="y" space_size="3" space_device="md" %}
@@ -618,7 +622,7 @@ Re-usable component example
 used in all your project's templates. Example (if key word arguments are
 skipped they fall back to their defaults):
 
-.. code-block::
+.. code-block:: template
 
     {% load frontend %}
     {% plugin "blockquote" quote_content="A well-known quotation." quote_origin="Famous Author" quote_alignment="center" %}{% endplugin %}
@@ -659,7 +663,7 @@ Re-usable component example
 used in all your project's templates. Example (if key word arguments are
 skipped they fall back to their defaults):
 
-.. code-block::
+.. code-block:: template
 
     {% load frontend %}
     {% plugin "code" code_type="pre" code_content="print('Hello, world!')" %}{% endplugin %}
@@ -688,11 +692,11 @@ Re-usable component example
 used in all your project's templates. Example (if key word arguments are
 skipped they fall back to their defaults):
 
-.. code-block::
+.. code-block:: template
 
     {% load frontend %}
     {% plugin "figure" figure_caption="Figure 1: An example figure" figure_alignment="center" %}
-        {% plugin "picture" %}{% endplugin %}
+        <img src="/static/example.jpg" alt="An example image">
     {% endplugin %}
 
 Parameters for ``{% plugin "figure" %}`` are:
@@ -731,10 +735,16 @@ Re-usable component example
 used in all your project's templates. Example (if key word arguments are
 skipped they fall back to their defaults):
 
-.. code-block::
+.. note::
+
+    Tab items read settings from their parent tab while rendering, so tabs have
+    to be built inside django CMS. Unlike the other components they cannot be
+    rendered standalone with the ``{% plugin %}`` tag.
+
+.. code-block:: django
 
     {% load frontend %}
-    {% plugin "tab" template="my_template" tab_type="nav-pills" tab_align="justify-content-center" %}
+    {% plugin "tab" tab_type="nav-pills" tab_alignment="justify-content-center" %}
         {% plugin "tabitem" tab_title="Tab 1" tab_bordered=True %}
             <h4>Content of tab 1</h4>
             <p> Some content...</p>
@@ -751,7 +761,7 @@ Parameters for ``{% plugin "tab" %}`` are:
 * ``template``: The template to use for the tabs. If not specified the default
   template is used.
 * ``tab_type``: The type of the tabs. If not specified the default type is used.
-* ``tab_align``: The alignment of the tabs. If not specified the default alignment
+* ``tab_alignment``: The alignment of the tabs. If not specified the default alignment
   is used.
 * ``tab_index``: The index of the initially active tab. If not specified the
   first tab is active.
@@ -940,12 +950,18 @@ Re-usable component example
 used in all your project's templates. Example (if key word arguments are
 skipped they fall back to their defaults):
 
-.. code-block::
+.. note::
 
-    {% load frontend %}
+    The navigation builds a menu from the current request, so it has to be
+    rendered within a django CMS page request. Unlike the other components it
+    cannot be rendered standalone with the ``{% plugin %}`` tag.
+
+.. code-block:: django
+
+    {% load frontend djangocms_link_tags %}
     {% plugin "navigation" navbar_design="light" navbar_breakpoint="lg" navbar_container=True %}
         {% plugin "navbrand" simple_content="My site" %}{% endplugin %}
-        {% plugin "navlink" external_link="/about/" %}About{% endplugin %}
+        {% plugin "navlink" link="/about/"|to_link %}About{% endplugin %}
         {% plugin "pagetree" start_level=0 %}{% endplugin %}
     {% endplugin %}
 

--- a/docs/source/plugins/grid.rst
+++ b/docs/source/plugins/grid.rst
@@ -48,17 +48,19 @@ Component example
 
 To create a container in a Django template, you need to load the `frontend` tags
 and then use the `plugin` template tag to render the container plugin.
-Below is an example of how you might do this::
+Below is an example of how you might do this:
+
+.. code-block:: template
 
     {% load frontend %}
 
     <!-- Example of using the plugin template tag for a container -->
-    {% plugin "container" container_type="container-fluid" %}
+    {% plugin "gridcontainer" container_type="container-fluid" %}
         {% plugin "gridrow" %}
-            {% plugin "column" xs_col=6 %}
+            {% plugin "gridcolumn" xs_col=6 %}
                 <p>This is the first column inside the container.</p>
             {% endplugin %}
-            {% plugin "column" xs_col=6 %}
+            {% plugin "gridcolumn" xs_col=6 %}
                 <p>This is the second column inside the container.</p>
             {% endplugin %}
         {% endplugin %}
@@ -150,7 +152,7 @@ Re-usable component example
 used in all your project's templates. Example (if key word arguments are
 skipped they fall back to their defaults):
 
-.. code-block::
+.. code-block:: template
 
     {% load frontend %}
     {% plugin "gridcontainer" container_type="container-fluid" %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,9 +66,9 @@ urls.Source = "https://github.com/django-cms/djangocms-frontend"
 
 [tool.setuptools]
 packages = [ "djangocms_frontend" ]
-dynamic.version = { attr = "djangocms_frontend.__version__" }
-package-data.djangocms_frontend = [ "static/**/*", "templates/**/*", "locale/**/*", "LICENSE", "README.rst" ]
+package-data.djangocms_frontend = [ "LICENSE", "locale/**/*", "README.rst", "static/**/*", "templates/**/*" ]
 package-data.exclude = [ "**/bundles/" ]
+dynamic.version = { attr = "djangocms_frontend.__version__" }
 
 [tool.black]
 exclude = """  .git
@@ -80,6 +80,17 @@ exclude = """  .git
   build
   dist
 """
+
+[tool.djlint]
+profile = "django"
+ignore = "H023,T003,H006,H031,D018,H021,H025"
+rule.flags = "re.DOTALL|re.I"
+rule.message = '.pk or .id should only be used with "|unlocalize"'
+rule.name = "D034"
+rule.patterns = [
+  "{{\\s*[a-zA-Z0-9_.]+\\.pk\\s*}}",
+  "{{\\s*[a-zA-Z0-9_.]+\\.id\\s*}}",
+]
 
 [tool.ruff]
 line-length = 119
@@ -103,19 +114,9 @@ lint.ignore = [
 
 [tool.isort]
 line_length = 119
-skip = [
-  "manage.py",
-  "*migrations*",
-  ".tox",
-  ".eggs",
-  ".env",
-  ".venv",
-  "data",
-]
-include_trailing_comma = true
 multi_line_output = 5
+include_trailing_comma = true
 lines_after_imports = 2
-default_section = "THIRDPARTY"
 sections = [
   "FUTURE",
   "STDLIB",
@@ -125,7 +126,17 @@ sections = [
   "FIRSTPARTY",
   "LOCALFOLDER",
 ]
+default_section = "THIRDPARTY"
 known_first_party = "djangocms_link"
+skip = [
+  "*migrations*",
+  ".eggs",
+  ".env",
+  ".tox",
+  ".venv",
+  "data",
+  "manage.py",
+]
 known_cms = [ "cms", "menus" ]
 known_django = "django"
 
@@ -160,10 +171,10 @@ exclude = [
 ]
 
 [tool.pytest]
-ini_options.DJANGO_SETTINGS_MODULE = "tests.test_settings"
-ini_options.pythonpath = [ "." ]
-ini_options.python_files = [ "test_*.py", "*_test.py" ]
 ini_options.testpaths = [ "tests" ]
+ini_options.pythonpath = [ "." ]
+ini_options.python_files = [ "*_test.py", "test_*.py" ]
+ini_options.DJANGO_SETTINGS_MODULE = "tests.test_settings"
 
 [tool.coverage]
 run.branch = true
@@ -185,14 +196,3 @@ report.exclude_lines = [
   "raise NotImplementedError",
 ]
 report.ignore_errors = true
-
-[tool.djlint]
-ignore = "H023,T003,H006,H031,D018,H021,H025"
-profile = "django"
-rule.name = "D034"
-rule.message = '.pk or .id should only be used with "|unlocalize"'
-rule.flags = "re.DOTALL|re.I"
-rule.patterns = [
-  "{{\\s*[a-zA-Z0-9_.]+\\.pk\\s*}}",
-  "{{\\s*[a-zA-Z0-9_.]+\\.id\\s*}}",
-]

--- a/tests/requirements/dj42_cms41.txt
+++ b/tests/requirements/dj42_cms41.txt
@@ -3,4 +3,3 @@
 Django>=4.2,<4.3
 django-cms>=4.1,<4.2
 djangocms-versioning>=2.0.0
-git+https://github.com/fsbraun/djangocms-url-manager.git@master#egg=djangocms-url-manager

--- a/tests/requirements/dj50_cms41.txt
+++ b/tests/requirements/dj50_cms41.txt
@@ -3,4 +3,3 @@
 Django>=5.0,<5.1
 django-cms>=4.1,<4.2
 djangocms-versioning>=2.0.0
-git+https://github.com/fsbraun/djangocms-url-manager.git@master#egg=djangocms-url-manager

--- a/tests/test_doc_examples.py
+++ b/tests/test_doc_examples.py
@@ -98,16 +98,24 @@ class DocPluginExamplesTest(TestFixture, CMSTestCase):
 
 
 def _make_test(doc, line_number, source):
+    location = f"{doc}:{line_number}"
+
     def test(self):
-        result = self._render(source)
+        try:
+            result = self._render(source)
+        except Exception as exc:  # noqa: BLE001 - re-raised with doc context
+            raise AssertionError(
+                f"{location} failed to render:\n"
+                f"{exc.__class__.__name__}: {exc}\n\n{source}"
+            ) from exc
         self.assertNotIn(
             UNREGISTERED_MARKER,
             result,
-            msg=f"{doc}:{line_number} uses a plugin slug that is not a registered component:\n{source}",
+            msg=f"{location} uses a plugin slug that is not a registered component:\n{source}",
         )
         self.assertTrue(
             result.strip(),
-            msg=f"{doc}:{line_number} rendered empty output:\n{source}",
+            msg=f"{location} rendered empty output:\n{source}",
         )
 
     return test

--- a/tests/test_doc_examples.py
+++ b/tests/test_doc_examples.py
@@ -1,0 +1,120 @@
+"""Render every runnable ``{% plugin %}`` example in the documentation.
+
+Examples that are meant to be copy-and-paste runnable are marked in the docs
+with ``.. code-block:: template``. This test extracts every such block and
+renders it, making sure that
+
+* every plugin slug used actually resolves to a registered component (otherwise
+  the tag renders a ``"... add its plugin class to the CMS_COMPONENT_PLUGINS
+  setting"`` comment), and
+* every keyword argument is a valid field (an unknown field raises while the
+  dummy instance is being built).
+
+This keeps the documentation honest: a renamed plugin or field, or a typo in a
+marked example, makes this test fail. Illustrative snippets that cannot be
+rendered standalone (e.g. carousel slides, which require a saved parent) simply
+use a plain ``.. code-block::`` and are not collected here.
+"""
+
+import re
+from pathlib import Path
+
+from cms.test_utils.testcases import CMSTestCase
+from django.template import engines
+from django.test import override_settings
+
+from tests.fixtures import TestFixture
+
+django_engine = engines["django"]
+
+DOCS_DIR = Path(__file__).resolve().parent.parent / "docs" / "source"
+
+# Substring of the comment emitted (in DEBUG) when a slug is not a component.
+UNREGISTERED_MARKER = "add its plugin class to the"
+
+# Marks a code block as a runnable template example to be verified here.
+TEMPLATE_BLOCK_RE = re.compile(r"^(?P<indent>\s*)\.\.\s+code-block::\s*template\s*$")
+
+
+def _iter_template_blocks(path):
+    """Yield ``(line_number, dedented_source)`` for each ``.. code-block:: template``."""
+    lines = path.read_text().splitlines()
+    i = 0
+    n = len(lines)
+    while i < n:
+        match = TEMPLATE_BLOCK_RE.match(lines[i])
+        if not match:
+            i += 1
+            continue
+        directive_indent = len(match.group("indent"))
+        block_start = i + 1
+        j = block_start
+        # Skip directive options (":linenos:" etc.) and blank lines.
+        while j < n and (not lines[j].strip() or lines[j].lstrip().startswith(":")):
+            j += 1
+        # Collect the indented block body.
+        body = []
+        block_indent = None
+        while j < n:
+            cur = lines[j]
+            if not cur.strip():
+                body.append("")
+                j += 1
+                continue
+            indent = len(cur) - len(cur.lstrip())
+            if indent <= directive_indent:
+                break
+            if block_indent is None:
+                block_indent = indent
+            body.append(cur[block_indent:])
+            j += 1
+        yield block_start + 1, "\n".join(body).strip("\n")
+        i = max(j, i + 1)
+
+
+def _collect_examples():
+    examples = []
+    for path in sorted(DOCS_DIR.rglob("*.rst")):
+        for line_number, source in _iter_template_blocks(path):
+            examples.append((path.relative_to(DOCS_DIR), line_number, source))
+    return examples
+
+
+EXAMPLES = _collect_examples()
+
+
+@override_settings(DEBUG=True)
+class DocPluginExamplesTest(TestFixture, CMSTestCase):
+    def test_examples_were_found(self):
+        """Guard against the parser silently finding nothing."""
+        self.assertTrue(
+            EXAMPLES,
+            "No `.. code-block:: template` examples found in the docs.",
+        )
+
+    def _render(self, source):
+        template = django_engine.from_string(source)
+        return template.render({"request": None})
+
+
+def _make_test(doc, line_number, source):
+    def test(self):
+        result = self._render(source)
+        self.assertNotIn(
+            UNREGISTERED_MARKER,
+            result,
+            msg=f"{doc}:{line_number} uses a plugin slug that is not a "
+            f"registered component:\n{source}",
+        )
+        self.assertTrue(
+            result.strip(),
+            msg=f"{doc}:{line_number} rendered empty output:\n{source}",
+        )
+
+    return test
+
+
+for _doc, _line_number, _source in EXAMPLES:
+    _slug = str(_doc).replace("/", "_").replace(".", "_").replace("-", "_")
+    _name = f"test_example_{_slug}_line_{_line_number}"
+    setattr(DocPluginExamplesTest, _name, _make_test(_doc, _line_number, _source))

--- a/tests/test_doc_examples.py
+++ b/tests/test_doc_examples.py
@@ -103,8 +103,7 @@ def _make_test(doc, line_number, source):
         self.assertNotIn(
             UNREGISTERED_MARKER,
             result,
-            msg=f"{doc}:{line_number} uses a plugin slug that is not a "
-            f"registered component:\n{source}",
+            msg=f"{doc}:{line_number} uses a plugin slug that is not a registered component:\n{source}",
         )
         self.assertTrue(
             result.strip(),

--- a/tests/test_doc_examples.py
+++ b/tests/test_doc_examples.py
@@ -104,10 +104,7 @@ def _make_test(doc, line_number, source):
         try:
             result = self._render(source)
         except Exception as exc:  # noqa: BLE001 - re-raised with doc context
-            raise AssertionError(
-                f"{location} failed to render:\n"
-                f"{exc.__class__.__name__}: {exc}\n\n{source}"
-            ) from exc
+            raise AssertionError(f"{location} failed to render:\n{exc.__class__.__name__}: {exc}\n\n{source}") from exc
         self.assertNotIn(
             UNREGISTERED_MARKER,
             result,


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Add a test suite that extracts all `.. code-block:: template` examples from the docs and renders them to verify plugin slugs resolve and produce non-empty output.