### PR TITLE
feat: Add nested components

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -20,10 +20,10 @@ jobs:
         requirements-file: [
             dj42_cms311.txt,
             dj42_cms41.txt,
-            dj50_cms41.txt,
-            dj51_cms41.txt,
             dj52_cms50.txt,
             dj60_cms50.txt,
+            dj52_cms51.txt,
+            dj60_cms51.txt,
         ]
         os: [
             ubuntu-latest,

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -43,6 +43,10 @@ jobs:
             requirements-file: dj60_cms50.txt
           - python-version: "3.11"
             requirements-file: dj60_cms50.txt
+          - python-version: "3.10"
+            requirements-file: dj60_cms51.txt
+          - python-version: "3.11"
+            requirements-file: dj60_cms51.txt
           # Python 3.12 and 3.13 don't support Django 4.2 with CMS 3.11
           - python-version: "3.12"
             requirements-file: dj42_cms311.txt

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 
-2.4.0 (2026.03-27
+2.4.0 (2026.03-27)
 ==================
 
 * feat: add "target" option to link plugin by @corentinbettiol in https://github.com/django-cms/djangocms-frontend/pull/355

--- a/djangocms_frontend/component_base.py
+++ b/djangocms_frontend/component_base.py
@@ -195,11 +195,18 @@ class CMSFrontendComponent(forms.Form, metaclass=ComponentMeta):
             # generated form has a single, consistent one.
             form_metaclass = type(cls._base_form)
             if not issubclass(form_metaclass, ComponentMeta):
-                form_metaclass = type(
-                    f"{cls.__name__}FormMeta",
-                    (ComponentMeta, form_metaclass),
-                    {},
-                )
+                try:
+                    form_metaclass = type(
+                        f"{cls.__name__}FormMeta",
+                        (ComponentMeta, form_metaclass),
+                        {},
+                    )
+                except TypeError as exc:  # pragma: no cover - defensive
+                    raise TypeError(
+                        f"Cannot build the admin form for component {cls.__name__!r}: its base form "
+                        f"{cls._base_form.__name__!r} uses a metaclass incompatible with ComponentMeta. "
+                        f"Provide a compatible '_base_form'."
+                    ) from exc
             cls._admin_form = form_metaclass(
                 f"{cls.__name__}Form",
                 (
@@ -269,7 +276,7 @@ class CMSFrontendComponent(forms.Form, metaclass=ComponentMeta):
         return cls._model
 
     @classmethod
-    def _get_child_classes(cls, slots: dict) -> list | str:
+    def _get_child_classes(cls, slots: dict) -> list | str | None:
         """Resolve the plugin's ``child_classes``.
 
         An explicit ``Meta.child_classes`` always wins and is extended with the
@@ -278,8 +285,10 @@ class CMSFrontendComponent(forms.Form, metaclass=ComponentMeta):
         children are resolved from the plugins that name this one in their
         ``parent_classes``, so the parent makes no assumptions about them. Before
         5.1 ``"auto"`` is unavailable, so those children are enumerated instead.
-        A plain ``allow_children`` component (no nested, no slots) stays
-        unrestricted on every version.
+
+        A plain ``allow_children`` component (no nested, no slots) returns
+        ``None`` -- django CMS reads that as "unrestricted". (An explicit empty
+        ``[]`` means "no children allowed", so it is left untouched.)
         """
         slot_classes = list(slots.keys())
         child_classes = getattr(cls._component_meta, "child_classes", None)
@@ -293,7 +302,7 @@ class CMSFrontendComponent(forms.Form, metaclass=ComponentMeta):
             # Older django CMS: enumerate nested components and slots explicitly.
             nested_classes = [f"{component.__name__}Plugin" for component in cls._nested_components]
             return nested_classes + slot_classes
-        return []
+        return None
 
     @classmethod
     def plugin_factory(cls) -> type:
@@ -360,7 +369,7 @@ class CMSFrontendComponent(forms.Form, metaclass=ComponentMeta):
                     "show_add_form": False,
                     "parent_classes": [cls.__name__ + "Plugin"],
                     "render_template": cls.slot_template,
-                    "model": SlotModel if cms_version >= "5" else CMSPlugin,
+                    "model": SlotModel if _cms_major_minor >= (5, 0) else CMSPlugin,
                     **slot.kwargs,
                 },
             )

--- a/djangocms_frontend/component_base.py
+++ b/djangocms_frontend/component_base.py
@@ -1,12 +1,22 @@
 import importlib
 
+from cms import __version__ as cms_version
 from cms.models import CMSPlugin
 from django import forms
 from django.apps import apps
+from django.forms.forms import DeclarativeFieldsMetaclass
+from django.template import TemplateDoesNotExist
+from django.template.loader import select_template
 from django.utils.encoding import force_str
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 from entangled.forms import EntangledModelForm
+
+# django CMS 5.1+ understands ``child_classes = "auto"`` to auto-detect which
+# plugins may be nested. On older versions ``child_classes`` is treated as a
+# membership test, so the sentinel must not be emitted there.
+_cms_major_minor = tuple(int(part) for part in cms_version.split(".")[:2] if part.isdigit())
+_CMS_AUTO_CHILD_CLASSES = _cms_major_minor >= (5, 1)
 
 
 def _import_or_empty(module, name):
@@ -53,7 +63,101 @@ class SlotModel(CMSPlugin):
         return format_html("<b>{}</b>", _("Slot"))
 
 
-class CMSFrontendComponent(forms.Form):
+def _component_qualname_parts(qualname: str) -> list[str]:
+    """Return the chain of lexically-nesting class names, ignoring any enclosing
+    function scope (e.g. ``Outer.test.<locals>.Tab.Item`` -> ``["Tab", "Item"]``)."""
+    parts = qualname.split(".")
+    if "<locals>" in parts:
+        # Keep only the class names that follow the innermost function scope
+        parts = parts[len(parts) - parts[::-1].index("<locals>") :]
+    return parts
+
+
+def _ensure_own_meta(cls) -> type:
+    """Return the component's *own* ``Meta`` class, creating one (inheriting any
+    ``Meta`` defined further up) if the component does not declare its own."""
+    if "Meta" in cls.__dict__:
+        return cls.__dict__["Meta"]
+    base = getattr(cls, "Meta", None)
+    meta = type("Meta", (base,) if base else (), {})
+    cls.Meta = meta
+    return meta
+
+
+def _insert_template_folder(path: str, template: str) -> str:
+    """Insert ``template`` as a folder right before the file name of ``path``,
+    e.g. ``xy/content.html`` + ``pills`` -> ``xy/pills/content.html``."""
+    head, sep, tail = path.rpartition("/")
+    return f"{head}/{template}/{tail}" if sep else f"{template}/{tail}"
+
+
+def _resolve_template(instance) -> str:
+    """Return the selected template string for ``instance``.
+
+    Reads ``template`` from the plugin's own config or, if it has none of its
+    own, walks up the parent chain so a child component follows the template
+    chosen on its (grand)parent."""
+    node = instance
+    while node is not None:
+        config = getattr(node, "config", None)
+        if isinstance(config, dict) and config.get("template"):
+            return config["template"]
+        parent = getattr(node, "parent", None)
+        if parent is None:
+            break
+        node = parent.get_plugin_instance()[0]
+    return ""
+
+
+class ComponentMeta(DeclarativeFieldsMetaclass):
+    """Metaclass that wires up nested ``CMSFrontendComponent`` declarations.
+
+    A component declared inside another component becomes a child plugin of the
+    outer one. Its name is qualified with the parent's (``Tab.Item`` ->
+    ``TabItem`` / ``TabItemPlugin``) and the parent/child relationship is filled
+    in automatically: ``parent_classes`` and ``require_parent`` on the child,
+    ``child_classes`` and ``allow_children`` on the parent. Explicit ``Meta``
+    values always take precedence.
+    """
+
+    def __new__(mcs, name, bases, namespace, **kwargs):
+        cls = super().__new__(mcs, name, bases, namespace, **kwargs)
+        if not any(isinstance(base, ComponentMeta) for base in bases):
+            # The ``CMSFrontendComponent`` base class itself - nothing to wire.
+            return cls
+
+        qualname = namespace.get("__qualname__", name)
+        parts = _component_qualname_parts(qualname)
+
+        # A nested component is qualified with its parent's name: Tab.Item -> TabItem
+        if len(parts) > 1:
+            cls.__name__ = "".join(parts)
+            parent_plugin = "".join(parts[:-1]) + "Plugin"
+            meta = _ensure_own_meta(cls)
+            if not hasattr(meta, "parent_classes"):
+                meta.parent_classes = [parent_plugin]
+            if not hasattr(meta, "require_parent"):
+                meta.require_parent = True
+
+        # Adopt directly-nested components as child plugins of this component.
+        # The nested children are wired up via their own ``parent_classes`` (set
+        # above); the parent only needs to allow children. Which children are
+        # permitted is resolved in ``_get_child_classes`` ("auto" on django CMS
+        # 5.1+, an explicit enumeration before that).
+        nested = [
+            value
+            for value in namespace.values()
+            if isinstance(value, ComponentMeta) and value.__qualname__.rsplit(".", 1)[0] == qualname
+        ]
+        cls._nested_components = nested
+        if nested:
+            meta = _ensure_own_meta(cls)
+            if not hasattr(meta, "allow_children"):
+                meta.allow_children = True
+        return cls
+
+
+class CMSFrontendComponent(forms.Form, metaclass=ComponentMeta):
     """Base class for frontend components:"""
 
     slot_template = "djangocms_frontend/slot.html"
@@ -63,6 +167,7 @@ class CMSFrontendComponent(forms.Form):
     _admin_form = None
     _model = None
     _plugin = None
+    _nested_components = []
     META_FIELDS = [
         "is_local",
         "is_slot",
@@ -79,13 +184,28 @@ class CMSFrontendComponent(forms.Form):
     @classmethod
     def admin_form_factory(cls, **kwargs) -> type:
         if cls._admin_form is None:
+            from djangocms_frontend.fields import TemplateChoiceMixin
             from djangocms_frontend.models import FrontendUIItem
 
             mixins = getattr(cls._component_meta, "mixins", [])
             mixins = _get_mixin_classes(mixins, "Form")
-            cls._admin_form = type(
+            # The component carries ``ComponentMeta`` while the base form carries
+            # entangled/model-form metaclasses (siblings under Django's
+            # ``DeclarativeFieldsMetaclass``). Build a combined metaclass so the
+            # generated form has a single, consistent one.
+            form_metaclass = type(cls._base_form)
+            if not issubclass(form_metaclass, ComponentMeta):
+                form_metaclass = type(
+                    f"{cls.__name__}FormMeta",
+                    (ComponentMeta, form_metaclass),
+                    {},
+                )
+            cls._admin_form = form_metaclass(
                 f"{cls.__name__}Form",
                 (
+                    # Hides the template field when only one choice is available;
+                    # a no-op for components without a `template` field.
+                    TemplateChoiceMixin,
                     *mixins,
                     cls,
                     cls._base_form,
@@ -149,6 +269,33 @@ class CMSFrontendComponent(forms.Form):
         return cls._model
 
     @classmethod
+    def _get_child_classes(cls, slots: dict) -> list | str:
+        """Resolve the plugin's ``child_classes``.
+
+        An explicit ``Meta.child_classes`` always wins and is extended with the
+        component's slots. When the component has nested components and/or slots
+        but no explicit list, django CMS 5.1+ uses ``"auto"``: the allowed
+        children are resolved from the plugins that name this one in their
+        ``parent_classes``, so the parent makes no assumptions about them. Before
+        5.1 ``"auto"`` is unavailable, so those children are enumerated instead.
+        A plain ``allow_children`` component (no nested, no slots) stays
+        unrestricted on every version.
+        """
+        slot_classes = list(slots.keys())
+        child_classes = getattr(cls._component_meta, "child_classes", None)
+        if child_classes == "auto":
+            return "auto"
+        if child_classes is not None:
+            return list(child_classes) + slot_classes
+        if cls._nested_components or slot_classes:
+            if _CMS_AUTO_CHILD_CLASSES:
+                return "auto"
+            # Older django CMS: enumerate nested components and slots explicitly.
+            nested_classes = [f"{component.__name__}Plugin" for component in cls._nested_components]
+            return nested_classes + slot_classes
+        return []
+
+    @classmethod
     def plugin_factory(cls) -> type:
         from .ui_plugin_base import CMSUIComponent
 
@@ -156,6 +303,9 @@ class CMSFrontendComponent(forms.Form):
             mixins = getattr(cls._component_meta, "mixins", [])
             slots = cls.get_slot_plugins()
             mixins = _get_mixin_classes(mixins)
+
+            allow_children = slots or getattr(cls._component_meta, "allow_children", False)
+            child_classes = cls._get_child_classes(slots)
 
             cls._plugin = type(
                 cls.__name__ + "Plugin",
@@ -169,8 +319,8 @@ class CMSFrontendComponent(forms.Form):
                     "module": getattr(cls._component_meta, "module", _("Components")),
                     "model": cls.plugin_model_factory(),
                     "form": cls.admin_form_factory(),
-                    "allow_children": slots or getattr(cls._component_meta, "allow_children", False),
-                    "child_classes": getattr(cls._component_meta, "child_classes", []) + list(slots.keys()),
+                    "allow_children": allow_children,
+                    "child_classes": child_classes,
                     "render_template": getattr(cls._component_meta, "render_template", CMSUIComponent.render_template),
                     "fieldsets": getattr(cls._component_meta, "fieldsets", cls._generate_fieldset()),
                     "change_form_template": getattr(
@@ -178,19 +328,14 @@ class CMSFrontendComponent(forms.Form):
                     ),
                     "slots": slots,
                     "save_model": cls.save_model,
+                    # Default template resolution (insert selected template folder
+                    # before the file name); a component-defined override wins.
+                    "get_render_template": cls.get_render_template,
                     **{
                         field: getattr(cls._component_meta, field)
                         for field in cls.META_FIELDS
                         if hasattr(cls._component_meta, field)
                     },
-                    **(
-                        {
-                            "get_render_template": cls.get_render_template,
-                            "TEMPLATES": cls.TEMPLATES,
-                        }
-                        if hasattr(cls, "get_render_template")
-                        else {}
-                    ),
                     "__module__": "djangocms_frontend.cms_plugins",
                 },
             )
@@ -215,7 +360,7 @@ class CMSFrontendComponent(forms.Form):
                     "show_add_form": False,
                     "parent_classes": [cls.__name__ + "Plugin"],
                     "render_template": cls.slot_template,
-                    # "model": SlotModel,  <-- uncomment once django CMS core is proxy safe in all current releases
+                    "model": SlotModel if cms_version >= "5" else CMSPlugin,
                     **slot.kwargs,
                 },
             )
@@ -237,6 +382,30 @@ class CMSFrontendComponent(forms.Form):
     @classmethod
     def _generate_fieldset(cls) -> list[tuple[str | None, dict]]:
         return [(None, {"fields": cls.declared_fields.keys()})]
+
+    def get_render_template(self, context, instance, placeholder):
+        """Default render template resolution for components.
+
+        When a ``template`` is selected, it is inserted as a folder right before
+        the file name of the plugin's ``render_template``, e.g.
+        ``xy/content.html`` -> ``xy/<template>/content.html``. The template is
+        taken from the plugin's own config or, if it has none, from the nearest
+        ancestor plugin that does -- so child components follow their parent's
+        template choice. Falls back to the bare ``render_template`` when no
+        template is selected or the resolved template does not exist.
+
+        Note: ``self`` is the plugin instance this method is attached to.
+        """
+        template = _resolve_template(instance)
+        render_template = self.render_template
+        if template:
+            candidate = _insert_template_folder(render_template, template)
+            try:
+                select_template([candidate])
+                return candidate
+            except TemplateDoesNotExist:
+                pass
+        return render_template
 
     def get_short_description(self) -> str:
         return self.config.get("title", "")

--- a/djangocms_frontend/component_base.py
+++ b/djangocms_frontend/component_base.py
@@ -94,14 +94,16 @@ def _insert_template_folder(path: str, template: str) -> str:
 def _resolve_template(instance) -> str:
     """Return the selected template string for ``instance``.
 
-    Reads ``template`` from the plugin's own config or, if it has none of its
-    own, walks up the parent chain so a child component follows the template
-    chosen on its (grand)parent."""
+    A component that declares a ``template`` field owns its choice. One that does
+    not inherits from the nearest ancestor that *declares* a ``template`` field
+    (its template owner). The walk stops at that owner even if its value is empty
+    -- so a tab item never reaches past its tab to a grandparent that happens to
+    have its own, unrelated ``template``."""
     node = instance
     while node is not None:
-        config = getattr(node, "config", None)
-        if isinstance(config, dict) and config.get("template"):
-            return config["template"]
+        if getattr(node, "_has_template_field", False):
+            config = getattr(node, "config", None)
+            return config.get("template", "") if isinstance(config, dict) else ""
         parent = getattr(node, "parent", None)
         if parent is None:
             break
@@ -261,6 +263,8 @@ class CMSFrontendComponent(forms.Form, metaclass=ComponentMeta):
                 ),
                 "get_short_description": cls.get_short_description,
                 "__module__": cls.__module__,
+                # Lets ``_resolve_template`` find the template-owning ancestor.
+                "_has_template_field": "template" in cls.declared_fields,
             }
             default_config = getattr(cls._component_meta, "default_config", None)
             if default_config:

--- a/djangocms_frontend/component_pool.py
+++ b/djangocms_frontend/component_pool.py
@@ -118,11 +118,17 @@ class Components:
     _discovered: bool = False
 
     def register(self, component):
+        self._register(component)
+        return component
+
+    def _register(self, component):
         if component.__name__ in self._registry:  # pragma: no cover
             warnings.warn(f"Component {component.__name__} already registered", stacklevel=2)
-            return component
+            return
         self._registry[component.__name__] = component.get_registration()
-        return component
+        # Nested components are not decorated themselves - register them too.
+        for nested in getattr(component, "_nested_components", []):
+            self._register(nested)
 
     def __getitem__(self, item):
         return self._registry[item]

--- a/djangocms_frontend/templatetags/frontend.py
+++ b/djangocms_frontend/templatetags/frontend.py
@@ -342,6 +342,31 @@ def get_slot(instance, slot_name):
     return tuple(generator())
 
 
+@register.filter
+def children(instance, plugin_type=None):
+    """Get the direct child plugin instances of ``instance``, optionally filtered
+    by component (plugin) type.
+
+    Unlike ``{% childplugins %}``, this returns the child *instances* rather than
+    their rendered HTML, so a component's template can iterate them more than once
+    (e.g. a tab nav and the tab panes) and render their fields and bodies itself.
+
+    The ``plugin_type`` may be given with or without the ``Plugin`` suffix, e.g.
+    both ``"TabComponentItem"`` and ``"TabComponentItemPlugin"`` work.
+
+    Usage: ``{% for item in instance|children:"TabComponentItem" %} ... {% endfor %}``
+    """
+    wanted = None
+    if plugin_type:
+        wanted = plugin_type if plugin_type.endswith("Plugin") else f"{plugin_type}Plugin"
+
+    return tuple(
+        child
+        for child in getattr(instance, "child_plugin_instances", None) or []
+        if wanted is None or child.plugin_type == wanted
+    )
+
+
 class InlineField(CMSEditableObject):
     name = "inline_field"
     options = Options(

--- a/djangocms_frontend/templatetags/frontend.py
+++ b/djangocms_frontend/templatetags/frontend.py
@@ -326,20 +326,27 @@ class RenderChildPluginsTag(Tag):
         return content
 
 
+def _child_plugins(instance, plugin_type=None):
+    """Yield the direct child plugin instances of ``instance``, optionally
+    filtered by exact ``plugin_type``. Shared core of ``children`` and
+    ``get_slot``; tolerates instances without ``child_plugin_instances``."""
+    for child in getattr(instance, "child_plugin_instances", None) or []:
+        if plugin_type is None or child.plugin_type == plugin_type:
+            yield child
+
+
 @register.filter
 def get_slot(instance, slot_name):
     """Get plugins for a specific slot directly from the instance. This is useful for rendering slots in a component's template,
     e.g. with {% for plugin in instance|get_slot:"community" %}.
     Usage: {% for plugin in instance|get_slot:"community" %} ... {% endfor %}
     """
-
-    def generator():
-        plugin_type = f"{instance.__class__.__name__}{slot_name.capitalize()}Plugin"
-        for plugin in instance.child_plugin_instances:
-            if plugin.plugin_type == plugin_type:
-                yield from plugin.child_plugin_instances
-
-    return tuple(generator())
+    slot_type = f"{instance.__class__.__name__}{slot_name.capitalize()}Plugin"
+    return tuple(
+        grandchild
+        for slot in _child_plugins(instance, slot_type)
+        for grandchild in getattr(slot, "child_plugin_instances", None) or []
+    )
 
 
 @register.filter
@@ -356,15 +363,9 @@ def children(instance, plugin_type=None):
 
     Usage: ``{% for item in instance|children:"TabComponentItem" %} ... {% endfor %}``
     """
-    wanted = None
-    if plugin_type:
-        wanted = plugin_type if plugin_type.endswith("Plugin") else f"{plugin_type}Plugin"
-
-    return tuple(
-        child
-        for child in getattr(instance, "child_plugin_instances", None) or []
-        if wanted is None or child.plugin_type == wanted
-    )
+    if plugin_type and not plugin_type.endswith("Plugin"):
+        plugin_type = f"{plugin_type}Plugin"
+    return tuple(_child_plugins(instance, plugin_type))
 
 
 class InlineField(CMSEditableObject):

--- a/docs/source/how-to/components-with-slots.rst
+++ b/docs/source/how-to/components-with-slots.rst
@@ -23,6 +23,14 @@ Slots are predefined placeholders in a component that:
 - Provide fallback content when a slot is empty
 - Are automatically created when a component instance is saved
 
+.. note::
+
+    Slots model *different kinds of content* in *fixed, named* regions (a media
+    area and a text area, for example). When you need a *repeating, typed* child
+    instead — many tab items or rows — reach for a
+    :ref:`nested component <nested_components>`. The two compose: a nested child
+    can itself declare slots.
+
 
 Defining slots
 ==============

--- a/docs/source/reference/template-filters.rst
+++ b/docs/source/reference/template-filters.rst
@@ -33,6 +33,49 @@ Load them with ``{% load frontend %}``.
     This is useful when you need more control over how slot content is rendered,
     compared to the ``{% childplugins %}`` tag which handles rendering automatically.
 
+.. py:function:: children(instance, plugin_type=None)
+
+    .. versionadded:: 2.5
+
+    Import from ``djangocms_frontend.templatetags.frontend``.
+
+    Get the direct child plugin **instances** of a component, optionally filtered
+    by component (plugin) type. Unlike :func:`get_slot`, which digs into a named
+    slot, ``children`` returns the component's own children; unlike
+    ``{% childplugins %}``, which returns rendered HTML, it returns the instances
+    themselves. That lets a template iterate the same children more than once — a
+    tab nav and the tab panes, say — and render their fields and bodies itself.
+
+    The ``plugin_type`` may be given with or without the ``Plugin`` suffix, so
+    both ``"TabItem"`` and ``"TabItemPlugin"`` resolve to the same type. Omitting
+    it returns every child. The return value is a re-iterable tuple, and it is
+    safe to use while a component template is being scanned for declaration (an
+    instance without children simply yields nothing).
+
+    :param instance: The component plugin instance
+    :param plugin_type: Optional component/plugin name to filter by
+    :return: Tuple of matching child plugin instances, in order
+
+    **Usage in templates:**
+
+    .. code-block:: django
+
+        {% load frontend cms_tags %}
+
+        <ul class="nav" role="tablist">
+            {% for item in instance|children:"TabItem" %}
+                <li>{{ item.tab_title }}</li>
+            {% endfor %}
+        </ul>
+        <div class="tab-content">
+            {% for item in instance|children:"TabItem" %}
+                {% render_plugin item %}
+            {% endfor %}
+        </div>
+
+    This is the natural companion to :ref:`nested components <nested_components>`,
+    where a parent component renders its repeating, typed children.
+
 .. py:function:: get_attributes(attribute_field, *add_classes)
 
     Simple tag that joins classes with an attributes field and returns all HTML attributes

--- a/docs/source/reference/template-filters.rst
+++ b/docs/source/reference/template-filters.rst
@@ -44,7 +44,7 @@ Load them with ``{% load frontend %}``.
     slot, ``children`` returns the component's own children; unlike
     ``{% childplugins %}``, which returns rendered HTML, it returns the instances
     themselves. That lets a template iterate the same children more than once — a
-    tab nav and the tab panes, say — and render their fields and bodies itself.
+    tab nav and the tab panes, say — and render their fields and bodies themselves.
 
     The ``plugin_type`` may be given with or without the ``Plugin`` suffix, so
     both ``"TabItem"`` and ``"TabItemPlugin"`` resolve to the same type. Omitting

--- a/docs/source/tutorial/custom_components.rst
+++ b/docs/source/tutorial/custom_components.rst
@@ -214,6 +214,123 @@ When you define slots:
 For more details and advanced usage, see :ref:`components-with-slots`.
 
 
+.. _nested_components:
+
+Nested components
+=================
+
+.. versionadded:: 2.5
+
+Slots are the right tool for *heterogeneous, fixed* regions (a media area and a
+text area, say). When you instead need a *repeating, typed* child — many tab
+items, accordion rows, or carousel slides — declare the child component **inside**
+its parent. The nesting wires up the parent/child relationship for you, so you
+never have to cross-reference plugin names.
+
+.. code-block:: python
+
+    from django import forms
+
+    from djangocms_frontend.component_base import CMSFrontendComponent
+    from djangocms_frontend.component_pool import components
+
+
+    @components.register
+    class Tabs(CMSFrontendComponent):
+        class Meta:
+            name = "Tabs"
+            render_template = "tabs/content.html"
+
+        template = forms.ChoiceField(choices=[("default", "Default"), ("pills", "Pills")])
+
+        class Item(CMSFrontendComponent):           # nested -> a child of Tabs
+            class Meta:
+                name = "Tab item"
+                render_template = "tabs/item.html"
+
+            label = forms.CharField()
+            # no parent_classes, no template field needed
+
+From this declaration ``djangocms-frontend`` derives:
+
+- **Qualified names.** ``Tabs.Item`` becomes ``TabsItem`` / ``TabsItemPlugin``.
+  The pattern is ``<Parent><Child>Plugin``, so a short inner name like ``Item``
+  reads naturally and can never collide with another component's ``Item``.
+  Nesting can go deeper (``Section.Row.Col`` → ``SectionRowColPlugin``).
+- **The parent/child link.** The child gets ``parent_classes = ["TabsPlugin"]``
+  and ``require_parent = True``; the parent gets ``allow_children = True``. On
+  django CMS 5.1+ the parent's ``child_classes`` is ``"auto"`` — the allowed
+  children are resolved from the plugins that name it in their
+  ``parent_classes`` — while on older versions the nested children are
+  enumerated explicitly. Either way, only ``Tab item`` plugins may be added.
+- **Registration.** Registering ``Tabs`` registers the nested ``Item`` too; you
+  do not decorate it separately.
+
+Any value you set explicitly on a child's ``Meta`` (``parent_classes``,
+``require_parent``, …) wins over the derived default, so the relationship stays
+fully customisable.
+
+
+Selecting the render template
+-----------------------------
+
+If a component has a ``template`` field, the selected value is inserted as a
+folder right before the file name of ``render_template``. With the
+``Tabs`` component above and ``template = "pills"`` the parent renders
+``tabs/pills/content.html`` instead of ``tabs/content.html``.
+
+A nested child without its own ``template`` field **inherits the choice from its
+parent** at render time. So ``Item`` renders ``tabs/pills/item.html`` — change
+the parent's template and all its items follow. If the resolved template does
+not exist, the bare ``render_template`` is used as a fallback.
+
+This behaviour comes from the default ``get_render_template`` that every
+component now provides; you only need to write a custom one for non-standard
+cases.
+
+
+Rendering the children
+----------------------
+
+Use the :py:func:`~djangocms_frontend.templatetags.frontend.children` filter to
+iterate a component's typed children. Because it returns the child *instances*
+(not rendered HTML), the parent template can loop them as often as it needs — for
+tabs, once for the nav and once for the panes:
+
+.. code-block:: django
+
+    {# tabs/<template>/content.html #}
+    {% load cms_tags frontend %}
+    <ul class="nav nav-{{ instance.template }}" role="tablist">
+        {% for item in instance|children:"TabsItem" %}
+            <li class="nav-item">
+                <button data-bs-target="#{% set_html_id item %}">{{ item.label }}</button>
+            </li>
+        {% endfor %}
+    </ul>
+    <div class="tab-content">
+        {% for item in instance|children:"TabsItem" %}
+            {% render_plugin item %}     {# renders tabs/<template>/item.html #}
+        {% endfor %}
+    </div>
+
+The child template renders its own content as usual:
+
+.. code-block:: django
+
+    {# tabs/<template>/item.html #}
+    {% load frontend %}
+    <div class="tab-pane" id="{% set_html_id instance %}">
+        {% childplugins instance %}{% endchildplugins %}
+    </div>
+
+.. tip::
+
+    A runnable, byte-for-byte reproduction of the built-in
+    ``djangocms_frontend.contrib.tabs`` plugin built entirely from nested
+    components lives in the ``examples`` app shipped with the project.
+
+
 Organizing fields with fieldsets
 =================================
 
@@ -346,6 +463,11 @@ Custom frontend components are a powerful tool for developers, but they have a l
 and can contain Python code to modify the behavior of a form. You cannot directly add Python code to
 the resulting plugin class with the exception of ``get_render_template()``. Similarly, you cannot add
 Python code the model class, in this case with the exception of ``get_short_description()``.
+
+Components already ship with a default ``get_render_template()`` that handles the
+``template`` field and nested-component template inheritance (see
+:ref:`nested_components`), so you only need to override it for non-standard
+template resolution.
 
 For maximun flexibility in your customized components, you can build a :ref:`custom Plugin<how-to-add-frontend-plugins>`.
 

--- a/docs/source/tutorial/custom_components.rst
+++ b/docs/source/tutorial/custom_components.rst
@@ -263,6 +263,8 @@ From this declaration ``djangocms-frontend`` derives:
   children are resolved from the plugins that name it in their
   ``parent_classes`` — while on older versions the nested children are
   enumerated explicitly. Either way, only ``Tab item`` plugins may be added.
+  (A plain ``allow_children`` component with no nested children stays
+  unrestricted; set ``child_classes = []`` explicitly to forbid all children.)
 - **Registration.** Registering ``Tabs`` registers the nested ``Item`` too; you
   do not decorate it separately.
 
@@ -469,7 +471,7 @@ Components already ship with a default ``get_render_template()`` that handles th
 :ref:`nested_components`), so you only need to override it for non-standard
 template resolution.
 
-For maximun flexibility in your customized components, you can build a :ref:`custom Plugin<how-to-add-frontend-plugins>`.
+For maximum flexibility in your customized components, you can build a :ref:`custom Plugin<how-to-add-frontend-plugins>`.
 
 
 Conclusion

--- a/examples/cms_components.py
+++ b/examples/cms_components.py
@@ -1,0 +1,128 @@
+"""Example components built on :class:`CMSFrontendComponent`.
+
+``Tabs`` is a drop-in reimplementation of ``djangocms_frontend.contrib.tabs``
+using the nested-component declaration: the repeating tab items are declared as
+a nested ``Item`` class instead of a separately registered plugin. It reuses the
+contrib tab templates and render mixins, so it renders byte-identically to the
+built-in tabs plugin (see ``tests/test_component_examples.py``).
+
+``Section`` demonstrates double nesting (``Section`` > ``Row`` > ``Col``) and the
+``children`` template filter.
+"""
+
+from django import forms
+from django.utils.translation import gettext_lazy as _
+
+from djangocms_frontend import settings
+from djangocms_frontend.common import AttributesMixin, PaddingMixin
+from djangocms_frontend.component_base import CMSFrontendComponent
+from djangocms_frontend.component_pool import components
+from djangocms_frontend.contrib import tabs as tabs_module
+from djangocms_frontend.contrib.tabs.constants import (
+    TAB_ALIGNMENT_CHOICES,
+    TAB_EFFECT_CHOICES,
+    TAB_TEMPLATE_CHOICES,
+    TAB_TYPE_CHOICES,
+)
+from djangocms_frontend.fields import AttributesFormField, ButtonGroup, IconGroup
+from djangocms_frontend.helpers import first_choice
+
+# Framework-specific render mixins, resolved exactly like the contrib plugin so
+# the same CSS classes are added during rendering.
+tab_renderer = settings.get_renderer(tabs_module)
+
+
+@components.register
+class Tabs(CMSFrontendComponent):
+    # Same render mixins, in the same order, as contrib's TabPlugin.
+    _plugin_mixins = [tab_renderer("Tab"), AttributesMixin]
+
+    class Meta:
+        name = _("Tabs (component)")
+        module = _("Examples")
+        # Own templates that render the tab items via the `children` filter;
+        # get_render_template inserts the selected template folder ("default")
+        # before the file name. Output is byte-identical to contrib.tabs.
+        render_template = "examples/tabs/tabs.html"
+        change_form_template = "djangocms_frontend/admin/tabs.html"
+
+    template = forms.ChoiceField(
+        label=_("Layout"),
+        choices=TAB_TEMPLATE_CHOICES,
+        initial=first_choice(TAB_TEMPLATE_CHOICES),
+    )
+    tab_type = forms.ChoiceField(
+        label=_("Type"),
+        choices=TAB_TYPE_CHOICES,
+        initial=first_choice(TAB_TYPE_CHOICES),
+        widget=ButtonGroup(attrs=dict(property="text")),
+    )
+    tab_alignment = forms.ChoiceField(
+        label=_("Alignment"),
+        choices=settings.EMPTY_CHOICE + TAB_ALIGNMENT_CHOICES,
+        initial=settings.EMPTY_CHOICE[0][0],
+        required=False,
+        widget=IconGroup(),
+    )
+    tab_index = forms.IntegerField(
+        label=_("Index"),
+        min_value=1,
+        required=False,
+        help_text=_("Index of element to open on page load starting at 1."),
+    )
+    tab_effect = forms.ChoiceField(
+        label=_("Animation effect"),
+        choices=settings.EMPTY_CHOICE + TAB_EFFECT_CHOICES,
+        required=False,
+    )
+    attributes = AttributesFormField()
+
+    def get_short_description(self):
+        text = f"({self.config.get('tab_type', '')})"
+        if self.config.get("tab_alignment"):
+            text += f" .{self.config['tab_alignment']}"
+        return text
+
+    class Item(CMSFrontendComponent):
+        # Same render mixins, in the same order, as contrib's TabItemPlugin.
+        _plugin_mixins = [tab_renderer("TabItem"), AttributesMixin, PaddingMixin]
+
+        class Meta:
+            name = _("Tab item (component)")
+            module = _("Examples")
+            render_template = "examples/tabs/item.html"
+            change_form_template = "djangocms_frontend/admin/tabs.html"
+
+        tab_title = forms.CharField(label=_("Tab title"), initial=_("New tab"), required=True)
+        tab_bordered = forms.BooleanField(
+            label=_("Bordered"),
+            required=False,
+            help_text=_("Add borders to the tab item"),
+        )
+        attributes = AttributesFormField()
+
+        def get_short_description(self):
+            return self.config.get("tab_title", "")
+
+
+@components.register
+class Section(CMSFrontendComponent):
+    """Double-nested layout component: Section > Row > Col."""
+
+    class Meta:
+        name = _("Section (component)")
+        module = _("Examples")
+        render_template = "examples/section/section.html"
+
+    class Row(CMSFrontendComponent):
+        class Meta:
+            name = _("Row")
+            module = _("Examples")
+            render_template = "examples/section/row.html"
+
+        class Col(CMSFrontendComponent):
+            class Meta:
+                name = _("Column")
+                module = _("Examples")
+                render_template = "examples/section/col.html"
+                allow_children = True  # holds arbitrary content plugins

--- a/examples/templates/examples/section/col.html
+++ b/examples/templates/examples/section/col.html
@@ -1,0 +1,3 @@
+{% load frontend %}<div class="col"{{ instance.get_attributes }}>
+    {% childplugins instance %}{% endchildplugins %}
+</div>

--- a/examples/templates/examples/section/row.html
+++ b/examples/templates/examples/section/row.html
@@ -1,0 +1,3 @@
+{% load cms_tags frontend %}<div class="row"{{ instance.get_attributes }}>
+    {% for col in instance|children:"SectionRowCol" %}{% render_plugin col %}{% endfor %}
+</div>

--- a/examples/templates/examples/section/section.html
+++ b/examples/templates/examples/section/section.html
@@ -1,0 +1,3 @@
+{% load cms_tags frontend %}<section{{ instance.get_attributes }}>
+    {% for row in instance|children:"SectionRow" %}{% render_plugin row %}{% endfor %}
+</section>

--- a/examples/templates/examples/tabs/default/item.html
+++ b/examples/templates/examples/tabs/default/item.html
@@ -1,0 +1,9 @@
+{% load cms_tags frontend %}
+<{{ instance.tag_type }}{{ instance.get_attributes }}
+ id="tab-{{ instance.pk|safe }}"
+ aria-labelledby="tab-label-{{ instance.pk|safe }}"
+ role="tabpanel">
+    {% for plugin in instance|children %}
+        {% render_plugin plugin %}
+    {% endfor %}
+</{{ instance.tag_type }}>

--- a/examples/templates/examples/tabs/default/tabs.html
+++ b/examples/templates/examples/tabs/default/tabs.html
@@ -1,0 +1,29 @@
+{% load cms_tags frontend %}{% spaceless %}
+    <{{ instance.tag_type }}{{ instance.get_attributes }}>
+    <ul class="nav {{ instance.tab_type }} {% if instance.tab_alignment %} {{ instance.tab_alignment }}{% endif %}" role="tablist">
+        {% for plugin in instance|children %}
+            <li class="nav-item">
+                <button
+                    class="nav-link{% if instance.tab_index == forloop.counter %} active{% endif %}"
+                    id="tab-label-{{ plugin.pk|safe }}"
+                    data-bs-toggle="tab"
+                    data-bs-target="#tab-{{ plugin.pk|safe }}"
+                    aria-controls="tab-{{ plugin.pk|safe }}"
+                    aria-selected="{% if instance.tab_index == forloop.counter %}true{% else %}false{% endif %}"
+                    type="button"
+                    role="tab">
+                    {{ plugin.tab_title }}
+                </button>
+            </li>
+        {% endfor %}
+    </ul>
+
+    <div class="tab-content{% if instance.tab_alignment == "flex-column" %} flex-fill{% endif %}">{% endspaceless %}
+        {% for plugin in instance|children %}
+            {% with parent=instance parentloop=forloop %}
+                {% render_plugin plugin %}
+            {% endwith %}
+        {% endfor %}{% spaceless %}
+    </div>
+    </{{ instance.tag_type }}>
+{% endspaceless %}

--- a/tests/requirements/dj50_cms41.txt
+++ b/tests/requirements/dj50_cms41.txt
@@ -1,5 +1,0 @@
--r base.txt
-
-Django>=5.0,<5.1
-django-cms>=4.1,<4.2
-djangocms-versioning>=2.0.0

--- a/tests/requirements/dj51_cms41.txt
+++ b/tests/requirements/dj51_cms41.txt
@@ -1,5 +1,0 @@
--r base.txt
-
-Django>=5.1,<5.2
-django-cms>=4.1.1,<4.2
-djangocms-versioning>=2.0.1

--- a/tests/requirements/dj52_cms51.txt
+++ b/tests/requirements/dj52_cms51.txt
@@ -1,0 +1,5 @@
+-r base.txt
+
+Django>=5.2,<6.0
+django-cms>=5.1.0a1,<5.2
+djangocms-versioning>=2.0.0

--- a/tests/requirements/dj52_cms51.txt
+++ b/tests/requirements/dj52_cms51.txt
@@ -3,3 +3,4 @@
 Django>=5.2,<6.0
 django-cms>=5.1.0a1,<5.2
 djangocms-versioning>=2.0.0
+django-treebeard<5  # can be removed for released 5.1.0

--- a/tests/requirements/dj60_cms51.txt
+++ b/tests/requirements/dj60_cms51.txt
@@ -1,0 +1,5 @@
+-r base.txt
+
+Django>=6.0,<6.1
+django-cms>=5.1.0a1,<5.2
+djangocms-versioning>=2.0.1

--- a/tests/requirements/dj60_cms51.txt
+++ b/tests/requirements/dj60_cms51.txt
@@ -3,3 +3,4 @@
 Django>=6.0,<6.1
 django-cms>=5.1.0a1,<5.2
 djangocms-versioning>=2.0.1
+django-treebeard<5

--- a/tests/test_app/cms_components.py
+++ b/tests/test_app/cms_components.py
@@ -66,6 +66,24 @@ class MyDefaultsComponent(CMSFrontendComponent):
 
 
 @components.register
+class TabComponent(CMSFrontendComponent):
+    class Meta:
+        name = "Tab Component"
+        render_template = "tabs/content.html"
+
+    title = forms.CharField(required=False, initial="Tabs")
+
+    class Item(CMSFrontendComponent):
+        # Nested component -> registered as TabComponentItemPlugin, a child of
+        # TabComponent whose template choice it inherits.
+        class Meta:
+            name = "Tab Item"
+            render_template = "tabs/item.html"
+
+        label = forms.CharField(required=True, initial="Tab")
+
+
+@components.register
 class MyCardWithFieldsets(CMSFrontendComponent):
     class Meta:
         name = "Card with Fieldsets"

--- a/tests/test_autocomponent.py
+++ b/tests/test_autocomponent.py
@@ -56,7 +56,12 @@ class AutoComponentTestCase(TestFixture, CMSTestCase):
         self.assertIn("hero_image", form.declared_fields)
         self.assertIn("config", form.declared_fields)  # Inherited from djangocms_frontend.models.FrontendUIItem
         self.assertTrue(plugin.allow_children)
-        self.assertEqual(plugin.child_classes, ["AutoHeroWithSlotsButtonsPlugin"])
+        # django CMS 5.1+ resolves slot children from their parent_classes ("auto");
+        # older versions enumerate them explicitly.
+        from djangocms_frontend.component_base import _CMS_AUTO_CHILD_CLASSES
+
+        expected_child_classes = "auto" if _CMS_AUTO_CHILD_CLASSES else ["AutoHeroWithSlotsButtonsPlugin"]
+        self.assertEqual(plugin.child_classes, expected_child_classes)
 
         self.assertIn("AutoHeroWithSlotsButtonsPlugin", plugin_pool.plugins)
         slot_plugin = plugin_pool.get_plugin("AutoHeroWithSlotsButtonsPlugin")

--- a/tests/test_autocomponent.py
+++ b/tests/test_autocomponent.py
@@ -153,6 +153,9 @@ class AutoComponentTestCase(TestFixture, CMSTestCase):
             ("tests.test_app", "test_app/cms_components/hero.html"),
             ("tests.test_app", "test_app/cms_components/with_slots.html"),
             ("tests.test_app", "test_app/cms_components/ui/button.html"),
+            ("examples", "examples/cms_components/feature_icon.html"),
+            ("examples", "examples/cms_components/feature_hanging.html"),
+            ("examples", "examples/cms_components/icon_grid.html"),
         }
         assert path_components == [("tests.test_app", "test_app/cms_components/ui/button.html")]
         assert private_components == [("tests.test_app", "test_app/my_components/test_component.htm")]

--- a/tests/test_component_examples.py
+++ b/tests/test_component_examples.py
@@ -1,0 +1,109 @@
+import re
+
+from cms.api import add_plugin
+from cms.test_utils.testcases import CMSTestCase
+
+from .fixtures import TestFixture
+
+# Identical configuration for both the contrib and the component tab trees.
+PARENT_CONFIG = dict(
+    template="default",
+    tab_type="nav-tabs",
+    tab_alignment="",
+    tab_index=1,
+    tab_effect="fade",
+    attributes={},
+)
+ITEM_CONFIGS = [
+    dict(tab_title="First tab", tab_bordered=True, attributes={}),
+    dict(tab_title="Second tab", tab_bordered=False, attributes={}),
+]
+
+
+def _normalize(html):
+    """Drop the only tree-specific difference: the auto-generated plugin pks
+    embedded in the tab element ids."""
+    html = re.sub(r"tab-label-\d+", "tab-label-PK", html)
+    html = re.sub(r"tab-\d+", "tab-PK", html)
+    return html.strip()
+
+
+class TabsByteIdenticalTestCase(TestFixture, CMSTestCase):
+    """The Tabs example component renders byte-identically to contrib.tabs."""
+
+    def _build_tabs(self, placeholder, parent_type, item_type):
+        parent = add_plugin(
+            placeholder=placeholder,
+            plugin_type=parent_type,
+            language=self.language,
+            config=dict(PARENT_CONFIG),
+        )
+        for item_config in ITEM_CONFIGS:
+            add_plugin(
+                target=parent,
+                placeholder=placeholder,
+                plugin_type=item_type,
+                language=self.language,
+                config=dict(item_config),
+            )
+        return parent
+
+    def _render_current(self):
+        self.publish(self.page, self.language)
+        with self.login_user_context(self.superuser):
+            response = self.client.get(self.request_url)
+        self.assertEqual(response.status_code, 200)
+        return response.content.decode("utf-8")
+
+    def test_renders_byte_identical_to_contrib(self):
+        from cms.models import CMSPlugin
+
+        # Render contrib tabs, then the example tabs into the same placeholder.
+        self._build_tabs(self.placeholder, "TabPlugin", "TabItemPlugin")
+        contrib_html = self._render_current()
+
+        CMSPlugin.objects.filter(placeholder=self.placeholder).delete()
+        self._build_tabs(self.placeholder, "TabsPlugin", "TabsItemPlugin")
+        example_html = self._render_current()
+
+        self.assertEqual(_normalize(example_html), _normalize(contrib_html))
+        # Sanity: the comparison is non-trivial (real tab markup was rendered).
+        self.assertIn("tab-pane", _normalize(contrib_html))
+        self.assertIn('<ul class="nav nav-tabs', _normalize(contrib_html))
+
+
+class DoublyNestedComponentTestCase(TestFixture, CMSTestCase):
+    """Section > Row > Col: double nesting wires up and renders."""
+
+    def test_registration_and_wiring(self):
+        from cms.plugin_pool import plugin_pool
+
+        for name in ("SectionPlugin", "SectionRowPlugin", "SectionRowColPlugin"):
+            self.assertIn(name, plugin_pool.plugins)
+
+        section = plugin_pool.get_plugin("SectionPlugin")
+        row = plugin_pool.get_plugin("SectionRowPlugin")
+        col = plugin_pool.get_plugin("SectionRowColPlugin")
+
+        self.assertTrue(section.allow_children)
+        self.assertEqual(row.parent_classes, ["SectionPlugin"])
+        self.assertTrue(row.require_parent)
+        self.assertEqual(col.parent_classes, ["SectionRowPlugin"])
+        self.assertTrue(col.require_parent)
+        self.assertTrue(col.allow_children)
+
+    def test_renders_nested_structure(self):
+        section = add_plugin(placeholder=self.placeholder, plugin_type="SectionPlugin", language=self.language)
+        row = add_plugin(
+            target=section, placeholder=self.placeholder, plugin_type="SectionRowPlugin", language=self.language
+        )
+        add_plugin(target=row, placeholder=self.placeholder, plugin_type="SectionRowColPlugin", language=self.language)
+        self.publish(self.page, self.language)
+
+        with self.login_user_context(self.superuser):
+            response = self.client.get(self.request_url)
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode("utf-8")
+        self.assertIn("<section", body)
+        self.assertIn('<div class="row"', body)
+        self.assertIn('<div class="col"', body)

--- a/tests/test_component_nesting.py
+++ b/tests/test_component_nesting.py
@@ -15,12 +15,14 @@ from tests.fixtures import TestFixture
 
 
 class _FakeInstance:
-    """Minimal stand-in for a plugin model instance (carries ``config`` and an
-    optional ``parent`` whose ``get_plugin_instance`` returns itself)."""
+    """Minimal stand-in for a plugin model instance (carries ``config``, the
+    ``_has_template_field`` marker, and an optional ``parent`` whose
+    ``get_plugin_instance`` returns itself)."""
 
-    def __init__(self, template=None, parent=None):
+    def __init__(self, template=None, parent=None, has_template_field=True):
         self.config = {"template": template} if template else {}
         self.parent = parent
+        self._has_template_field = has_template_field
 
     def get_plugin_instance(self):
         return (self, None)
@@ -239,12 +241,26 @@ class GetRenderTemplateTestCase(SimpleTestCase):
 
     def test_child_inherits_parent_template(self):
         parent = _FakeInstance(template="pills")
-        child = _FakeInstance(template=None, parent=parent)
+        # The child has no template field of its own -> inherits from the parent.
+        child = _FakeInstance(template=None, parent=parent, has_template_field=False)
         plugin = _FakePlugin("tabs/item.html")
         with mock.patch.object(component_base, "select_template") as select:
             result = plugin.get_render_template({}, child, None)
         self.assertEqual(result, "tabs/pills/item.html")
         select.assert_called_once_with(["tabs/pills/item.html"])
+
+    def test_child_stops_at_template_owner_not_grandparent(self):
+        # A grandparent with its own template must not leak into the child when
+        # the immediate template owner (the parent) has an empty selection.
+        grandparent = _FakeInstance(template="grid")
+        parent = _FakeInstance(template=None, parent=grandparent)  # owns template, empty
+        child = _FakeInstance(template=None, parent=parent, has_template_field=False)
+        plugin = _FakePlugin("tabs/item.html")
+        with mock.patch.object(component_base, "select_template") as select:
+            result = plugin.get_render_template({}, child, None)
+        # Resolves to the parent's (empty) template -> bare path, never "grid".
+        self.assertEqual(result, "tabs/item.html")
+        select.assert_not_called()
 
     def test_insert_template_folder_helper(self):
         self.assertEqual(_insert_template_folder("tabs/content.html", "pills"), "tabs/pills/content.html")

--- a/tests/test_component_nesting.py
+++ b/tests/test_component_nesting.py
@@ -1,0 +1,260 @@
+from unittest import mock
+
+from cms.test_utils.testcases import CMSTestCase
+from django import forms
+from django.template import TemplateDoesNotExist
+from django.test import SimpleTestCase
+
+from djangocms_frontend import component_base
+from djangocms_frontend.component_base import (
+    CMSFrontendComponent,
+    _component_qualname_parts,
+    _insert_template_folder,
+)
+from tests.fixtures import TestFixture
+
+
+class _FakeInstance:
+    """Minimal stand-in for a plugin model instance (carries ``config`` and an
+    optional ``parent`` whose ``get_plugin_instance`` returns itself)."""
+
+    def __init__(self, template=None, parent=None):
+        self.config = {"template": template} if template else {}
+        self.parent = parent
+
+    def get_plugin_instance(self):
+        return (self, None)
+
+
+class _FakePlugin:
+    """Stands in for the plugin the component's ``get_render_template`` is
+    attached to - it only needs a ``render_template``."""
+
+    get_render_template = CMSFrontendComponent.get_render_template
+
+    def __init__(self, render_template):
+        self.render_template = render_template
+
+
+class ComponentNestingTestCase(SimpleTestCase):
+    """Unit tests for the ``ComponentMeta`` nesting wiring."""
+
+    def test_nested_component_is_qualified(self):
+        class Tab(CMSFrontendComponent):
+            class Meta:
+                name = "Tabs"
+                render_template = "tabs/content.html"
+
+            class Item(CMSFrontendComponent):
+                class Meta:
+                    name = "Tab item"
+                    render_template = "tabs/item.html"
+
+        # Parent keeps its name, child is qualified: Tab.Item -> TabItem.
+        self.assertEqual(Tab.__name__, "Tab")
+        self.assertEqual(Tab.Item.__name__, "TabItem")
+
+    def test_nested_relationship_is_wired_up(self):
+        class Tab(CMSFrontendComponent):
+            class Meta:
+                name = "Tabs"
+                render_template = "tabs/content.html"
+
+            class Item(CMSFrontendComponent):
+                class Meta:
+                    name = "Tab item"
+                    render_template = "tabs/item.html"
+
+        self.assertEqual(Tab.Item.Meta.parent_classes, ["TabPlugin"])
+        self.assertTrue(Tab.Item.Meta.require_parent)
+        self.assertTrue(Tab.Meta.allow_children)
+        self.assertEqual([c.__name__ for c in Tab._nested_components], ["TabItem"])
+
+    def test_explicit_meta_overrides_nesting_defaults(self):
+        class Box(CMSFrontendComponent):
+            class Meta:
+                name = "Box"
+                render_template = "box.html"
+
+            class Item(CMSFrontendComponent):
+                class Meta:
+                    name = "Item"
+                    render_template = "item.html"
+                    parent_classes = ["SomethingElsePlugin"]
+                    require_parent = False
+
+        self.assertEqual(Box.Item.Meta.parent_classes, ["SomethingElsePlugin"])
+        self.assertFalse(Box.Item.Meta.require_parent)
+
+    def test_deep_nesting_qualifies_names_and_parents(self):
+        class Tab(CMSFrontendComponent):
+            class Meta:
+                name = "T"
+                render_template = "t.html"
+
+            class Item(CMSFrontendComponent):
+                class Meta:
+                    name = "I"
+                    render_template = "i.html"
+
+                class Action(CMSFrontendComponent):
+                    class Meta:
+                        name = "A"
+                        render_template = "a.html"
+
+        self.assertEqual(Tab.Item.__name__, "TabItem")
+        self.assertEqual(Tab.Item.Action.__name__, "TabItemAction")
+        self.assertEqual(Tab.Item.Action.Meta.parent_classes, ["TabItemPlugin"])
+        self.assertEqual([c.__name__ for c in Tab.Item._nested_components], ["TabItemAction"])
+
+    def test_top_level_component_is_not_nested(self):
+        class Plain(CMSFrontendComponent):
+            class Meta:
+                name = "Plain"
+                render_template = "plain.html"
+
+        self.assertEqual(Plain.__name__, "Plain")
+        self.assertFalse(hasattr(Plain.Meta, "parent_classes"))
+        self.assertEqual(Plain._nested_components, [])
+
+    def test_component_qualname_parts(self):
+        self.assertEqual(_component_qualname_parts("Tab"), ["Tab"])
+        self.assertEqual(_component_qualname_parts("Tab.Item"), ["Tab", "Item"])
+        # Function-local definitions ignore the enclosing scope.
+        self.assertEqual(_component_qualname_parts("mod.fn.<locals>.Tab.Item"), ["Tab", "Item"])
+
+
+class ChildClassesAutoTestCase(SimpleTestCase):
+    """Unit tests for ``_get_child_classes`` across django CMS versions."""
+
+    def _nested_parent(self):
+        class Tab(CMSFrontendComponent):
+            class Meta:
+                name = "Tabs"
+                render_template = "tabs/content.html"
+
+            class Item(CMSFrontendComponent):
+                class Meta:
+                    name = "Tab item"
+                    render_template = "tabs/item.html"
+
+        return Tab
+
+    def test_nested_parent_uses_auto_on_cms_51(self):
+        Tab = self._nested_parent()
+        with mock.patch.object(component_base, "_CMS_AUTO_CHILD_CLASSES", True):
+            self.assertEqual(Tab._get_child_classes({}), "auto")
+
+    def test_nested_parent_enumerates_before_cms_51(self):
+        Tab = self._nested_parent()
+        with mock.patch.object(component_base, "_CMS_AUTO_CHILD_CLASSES", False):
+            self.assertEqual(Tab._get_child_classes({}), ["TabItemPlugin"])
+
+    def test_slots_use_auto_on_cms_51(self):
+        class Hero(CMSFrontendComponent):
+            class Meta:
+                name = "Hero"
+                render_template = "hero.html"
+                slots = (("title", "Title"),)
+
+        slots = Hero.get_slot_plugins()
+        with mock.patch.object(component_base, "_CMS_AUTO_CHILD_CLASSES", True):
+            self.assertEqual(Hero._get_child_classes(slots), "auto")
+        with mock.patch.object(component_base, "_CMS_AUTO_CHILD_CLASSES", False):
+            self.assertEqual(Hero._get_child_classes(slots), ["HeroTitlePlugin"])
+
+    def test_plain_allow_children_stays_unrestricted(self):
+        class Box(CMSFrontendComponent):
+            class Meta:
+                name = "Box"
+                render_template = "box.html"
+                allow_children = True
+
+        # No nested components and no slots: unrestricted on every version.
+        for flag in (True, False):
+            with mock.patch.object(component_base, "_CMS_AUTO_CHILD_CLASSES", flag):
+                self.assertEqual(Box._get_child_classes({}), [])
+
+    def test_explicit_child_classes_respected_and_extended_with_slots(self):
+        class Box(CMSFrontendComponent):
+            class Meta:
+                name = "Box"
+                render_template = "box.html"
+                child_classes = ["FooPlugin"]
+                slots = (("title", "Title"),)
+
+        slots = Box.get_slot_plugins()
+        with mock.patch.object(component_base, "_CMS_AUTO_CHILD_CLASSES", True):
+            self.assertEqual(Box._get_child_classes(slots), ["FooPlugin", "BoxTitlePlugin"])
+
+    def test_explicit_auto_is_respected_on_old_cms(self):
+        class Box(CMSFrontendComponent):
+            class Meta:
+                name = "Box"
+                render_template = "box.html"
+                child_classes = "auto"
+
+        with mock.patch.object(component_base, "_CMS_AUTO_CHILD_CLASSES", False):
+            self.assertEqual(Box._get_child_classes({}), "auto")
+
+
+class GetRenderTemplateTestCase(SimpleTestCase):
+    """Unit tests for the default ``get_render_template`` resolution."""
+
+    def test_inserts_template_folder_before_file_name(self):
+        plugin = _FakePlugin("tabs/content.html")
+        instance = _FakeInstance(template="pills")
+        with mock.patch.object(component_base, "select_template") as select:
+            result = plugin.get_render_template({}, instance, None)
+        self.assertEqual(result, "tabs/pills/content.html")
+        select.assert_called_once_with(["tabs/pills/content.html"])
+
+    def test_falls_back_to_bare_template_when_missing(self):
+        plugin = _FakePlugin("tabs/content.html")
+        instance = _FakeInstance(template="ghost")
+        with mock.patch.object(component_base, "select_template", side_effect=TemplateDoesNotExist("x")):
+            result = plugin.get_render_template({}, instance, None)
+        self.assertEqual(result, "tabs/content.html")
+
+    def test_returns_bare_template_without_selection(self):
+        plugin = _FakePlugin("tabs/content.html")
+        instance = _FakeInstance(template=None)
+        with mock.patch.object(component_base, "select_template") as select:
+            result = plugin.get_render_template({}, instance, None)
+        self.assertEqual(result, "tabs/content.html")
+        select.assert_not_called()
+
+    def test_child_inherits_parent_template(self):
+        parent = _FakeInstance(template="pills")
+        child = _FakeInstance(template=None, parent=parent)
+        plugin = _FakePlugin("tabs/item.html")
+        with mock.patch.object(component_base, "select_template") as select:
+            result = plugin.get_render_template({}, child, None)
+        self.assertEqual(result, "tabs/pills/item.html")
+        select.assert_called_once_with(["tabs/pills/item.html"])
+
+    def test_insert_template_folder_helper(self):
+        self.assertEqual(_insert_template_folder("tabs/content.html", "pills"), "tabs/pills/content.html")
+        self.assertEqual(_insert_template_folder("content.html", "pills"), "pills/content.html")
+
+
+class NestedComponentRegistrationTestCase(TestFixture, CMSTestCase):
+    """Integration test: a nested component registers as a child plugin."""
+
+    def test_nested_component_is_registered_as_child_plugin(self):
+        from cms.plugin_pool import plugin_pool
+
+        from djangocms_frontend.component_base import _CMS_AUTO_CHILD_CLASSES
+
+        self.assertIn("TabComponentPlugin", plugin_pool.plugins)
+        self.assertIn("TabComponentItemPlugin", plugin_pool.plugins)
+
+        parent = plugin_pool.get_plugin("TabComponentPlugin")
+        child = plugin_pool.get_plugin("TabComponentItemPlugin")
+
+        self.assertTrue(parent.allow_children)
+        self.assertEqual(child.parent_classes, ["TabComponentPlugin"])
+        self.assertTrue(child.require_parent)
+
+        expected = "auto" if _CMS_AUTO_CHILD_CLASSES else ["TabComponentItemPlugin"]
+        self.assertEqual(parent.child_classes, expected)

--- a/tests/test_component_nesting.py
+++ b/tests/test_component_nesting.py
@@ -170,7 +170,20 @@ class ChildClassesAutoTestCase(SimpleTestCase):
                 render_template = "box.html"
                 allow_children = True
 
-        # No nested components and no slots: unrestricted on every version.
+        # No nested components and no slots: ``None`` (django CMS reads that as
+        # "unrestricted"; an explicit ``[]`` would instead mean "no children").
+        for flag in (True, False):
+            with mock.patch.object(component_base, "_CMS_AUTO_CHILD_CLASSES", flag):
+                self.assertIsNone(Box._get_child_classes({}))
+
+    def test_explicit_empty_child_classes_means_no_children(self):
+        class Box(CMSFrontendComponent):
+            class Meta:
+                name = "Box"
+                render_template = "box.html"
+                allow_children = True
+                child_classes = []  # explicit: no children allowed
+
         for flag in (True, False):
             with mock.patch.object(component_base, "_CMS_AUTO_CHILD_CLASSES", flag):
                 self.assertEqual(Box._get_child_classes({}), [])

--- a/tests/test_frontend_templatetags.py
+++ b/tests/test_frontend_templatetags.py
@@ -14,6 +14,7 @@ from djangocms_frontend.contrib.alert.cms_plugins import AlertPlugin
 from djangocms_frontend.contrib.alert.forms import AlertForm
 from djangocms_frontend.contrib.alert.models import Alert
 from djangocms_frontend.templatetags.frontend import (
+    children,
     get_attributes,
     get_slot,
     is_registering_component,
@@ -285,6 +286,53 @@ class GetSlotFilterTestCase(TestCase):
 
         result = get_slot(instance, "community")
         self.assertEqual(result, (child_a, child_b))
+
+
+class ChildrenFilterTestCase(TestCase):
+    """Tests for the children filter."""
+
+    class FakePlugin:
+        def __init__(self, plugin_type):
+            self.plugin_type = plugin_type
+
+    class Parent:
+        def __init__(self, child_plugin_instances):
+            self.child_plugin_instances = child_plugin_instances
+
+    def test_returns_tuple(self):
+        """children must return a (re-iterable) tuple, not a generator."""
+        result = children(self.Parent(child_plugin_instances=[]))
+        self.assertIsInstance(result, tuple)
+
+    def test_returns_all_children_without_filter(self):
+        a = self.FakePlugin("TabComponentItemPlugin")
+        b = self.FakePlugin("SomethingElsePlugin")
+        instance = self.Parent(child_plugin_instances=[a, b])
+        self.assertEqual(children(instance), (a, b))
+
+    def test_filters_by_plugin_type(self):
+        a = self.FakePlugin("TabComponentItemPlugin")
+        b = self.FakePlugin("SomethingElsePlugin")
+        c = self.FakePlugin("TabComponentItemPlugin")
+        instance = self.Parent(child_plugin_instances=[a, b, c])
+        self.assertEqual(children(instance, "TabComponentItemPlugin"), (a, c))
+
+    def test_plugin_suffix_is_optional(self):
+        a = self.FakePlugin("TabComponentItemPlugin")
+        b = self.FakePlugin("SomethingElsePlugin")
+        instance = self.Parent(child_plugin_instances=[a, b])
+        # Both spellings resolve to the same plugin_type.
+        self.assertEqual(children(instance, "TabComponentItem"), (a,))
+        self.assertEqual(children(instance, "TabComponentItemPlugin"), (a,))
+
+    def test_no_match_returns_empty_tuple(self):
+        instance = self.Parent(child_plugin_instances=[self.FakePlugin("SomethingElsePlugin")])
+        self.assertEqual(children(instance, "TabComponentItem"), ())
+
+    def test_missing_child_plugin_instances_returns_empty_tuple(self):
+        """Safe during component scanning where instance has no children (e.g. {})."""
+        self.assertEqual(children({}), ())
+        self.assertEqual(children({}, "TabComponentItem"), ())
 
 
 class InlineFieldTestCase(TestFixture, CMSTestCase):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -34,6 +34,7 @@ INSTALLED_APPS = [
     "djangocms_frontend.contrib.utilities",
     "sekizai",
     "tests.test_app",
+    "examples",
 ]
 
 try:  # V4 test?


### PR DESCRIPTION
## Summary by Sourcery

Introduce nested frontend components with automatic plugin wiring, configurable child relationships, and shared template selection across parent/child plugins.

New Features:
- Support declaring nested CMSFrontendComponent classes that automatically register as related child plugins.
- Add a children template filter to iterate over child plugin instances, optionally filtered by component type.
- Provide example Tabs and Section components demonstrating nested components and the children filter, with templates matching existing contrib tabs output.

Enhancements:
- Unify plugin child_classes handling to support django CMS 5.1+ auto child resolution while remaining compatible with older versions.
- Add default render template resolution that derives variant templates from a selected template folder and propagates template choice through component hierarchies.
- Ensure generated admin forms combine component and model-form metaclasses and hide redundant template selectors when only one choice exists.

Documentation:
- Update component how-to, template filter reference, and custom components tutorial to cover nested components and the new children filter.

Tests:
- Add comprehensive unit and integration tests for nested component wiring, child_classes resolution, template resolution, the children filter, and the example components.
- Extend autocomponent tests to discover example components and configure tests to load the examples app.