### PR TITLE
fix: Use getattr for TEMPLATES attribute in component_base

### DIFF
--- a/djangocms_frontend/component_base.py
+++ b/djangocms_frontend/component_base.py
@@ -186,7 +186,7 @@ class CMSFrontendComponent(forms.Form):
                     **(
                         {
                             "get_render_template": cls.get_render_template,
-                            "TEMPLATES": getattr(cls, "TEMPLATES", (("default", "Default),)),
+                            "TEMPLATES": getattr(cls, "TEMPLATES", (("default", "Default"),)),
                         }
                         if hasattr(cls, "get_render_template")
                         else {}

--- a/djangocms_frontend/component_base.py
+++ b/djangocms_frontend/component_base.py
@@ -186,7 +186,7 @@ class CMSFrontendComponent(forms.Form):
                     **(
                         {
                             "get_render_template": cls.get_render_template,
-                            "TEMPLATES": cls.TEMPLATES,
+                            "TEMPLATES": getattr(cls, "TEMPLATES", (("default", "Default),)),
                         }
                         if hasattr(cls, "get_render_template")
                         else {}


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent attribute errors in plugin_factory by safely accessing the TEMPLATES attribute with a default value.