### PR TITLE
feat: Add PluginMixin class to frontend components

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,8 +7,8 @@ Changelog
 
 * feat: feat: Add PluginMixin class to frontend components by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/384
 * feat: Add rename subcommand for renaming ui plugins and components. by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/370
+* feat: Heading ID (Heading Plugin) is now a prepopulated field by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/379
 * feat: Ensure `get_slot` gives a tuple (instead of a generator) by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/375
-* feat: Heading ID is now a prepopulated field by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/379
 * fix: Add form ignored `dafault_config` by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/365
 * fix: plugin template tag calls were not isolated by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/367
 * fix: Read-only placeholders rendered inline fields editable by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/368

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,24 @@
 Changelog
 =========
 
+2.5.0 (2026-06-29)
+==================
 
-2.4.0 (2026.03-27
+* feat: feat: Add PluginMixin class to frontend components by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/384
+* feat: Add rename subcommand for renaming ui plugins and components. by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/370
+* feat: Ensure `get_slot` gives a tuple (instead of a generator) by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/375
+* feat: Heading ID is now a prepopulated field by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/379
+* fix: Add form ignored `dafault_config` by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/365
+* fix: plugin template tag calls were not isolated by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/367
+* fix: Read-only placeholders rendered inline fields editable by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/368
+* fix: Add space between element attributes into AbstractFrontendUIItem… by @zbohm in https://github.com/django-cms/djangocms-frontend/pull/369
+* fix: Forms did not validate if advanced settings had been disabled by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/371
+* fix: Default configs of shared mixins leaked into other plugins by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/373
+* fix: Let icon have <i> as default tag (w/o advanced settings) by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/374
+* fix: Use getattr for TEMPLATES attribute in component_base by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/382
+* docs: Add tests for code examples in the docs by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/380
+
+2.4.0 (2026-03-27)
 ==================
 
 * feat: add "target" option to link plugin by @corentinbettiol in https://github.com/django-cms/djangocms-frontend/pull/355

--- a/djangocms_frontend/__init__.py
+++ b/djangocms_frontend/__init__.py
@@ -19,4 +19,4 @@ Release logic:
 13. Github actions will publish the new package to pypi
 """
 
-__version__ = "2.4.0"
+__version__ = "2.5.0"

--- a/djangocms_frontend/apps.py
+++ b/djangocms_frontend/apps.py
@@ -13,6 +13,7 @@ class DjangocmsFrontendConfig(apps.AppConfig):
         plugin_tag.setup()
         checks.register(check_settings)
         checks.register(check_installed_apps)
+        checks.register(check_component_plugin_behavior)
 
 
 def check_settings(*args, **kwargs):  # pragma: no cover
@@ -41,6 +42,32 @@ def check_settings(*args, **kwargs):  # pragma: no cover
                 obj="settings.DJANGOCMS_FRONTEND_LINK_MODELS",
             )
         )
+    return warnings
+
+
+def check_component_plugin_behavior(*args, **kwargs):
+    """Report components that declare plugin behavior directly on the component class.
+
+    ``save_model``, ``get_render_template`` and ``TEMPLATES`` belong in a nested
+    ``PluginMixin`` class. Declaring them on the component itself is deprecated; the
+    factory still grafts them onto the plugin for backwards compatibility.
+    """
+    from .component_pool import components
+
+    warnings = []
+    for name, component in components._components.items():
+        attrs = component._deprecated_plugin_attrs()
+        if attrs:
+            warnings.append(
+                checks.Warning(
+                    f"Component {name!r} declares {', '.join(repr(attr) for attr in attrs)} directly "
+                    f"on the component class, which is deprecated.",
+                    "Move the declaration(s) into a nested 'PluginMixin' class. They are still applied "
+                    "for backwards compatibility, but support will be removed in a future release.",
+                    id="djangocms_frontend.W003",
+                    obj=f"{component.__module__}.{component.__qualname__}",
+                )
+            )
     return warnings
 
 

--- a/djangocms_frontend/component_base.py
+++ b/djangocms_frontend/component_base.py
@@ -157,10 +157,19 @@ class CMSFrontendComponent(forms.Form):
             slots = cls.get_slot_plugins()
             mixins = _get_mixin_classes(mixins)
 
+            # Plugin-side behavior (``save_model``, ``get_render_template``,
+            # ``TEMPLATES``, ...) is declared in a nested ``PluginMixin`` class and
+            # mixed into the generated plugin's bases. Living in the MRO means its
+            # methods can call ``super()`` normally instead of being grafted onto
+            # the plugin as standalone functions.
+            plugin_mixin = getattr(cls, "PluginMixin", None)
+            behavior = (plugin_mixin,) if plugin_mixin is not None else ()
+
             cls._plugin = type(
                 cls.__name__ + "Plugin",
                 (
                     *mixins,
+                    *behavior,
                     *cls._plugin_mixins,
                     CMSUIComponent,
                 ),
@@ -177,20 +186,12 @@ class CMSFrontendComponent(forms.Form):
                         cls._component_meta, "change_form_template", "djangocms_frontend/admin/base.html"
                     ),
                     "slots": slots,
-                    "save_model": cls.save_model,
                     **{
                         field: getattr(cls._component_meta, field)
                         for field in cls.META_FIELDS
                         if hasattr(cls._component_meta, field)
                     },
-                    **(
-                        {
-                            "get_render_template": cls.get_render_template,
-                            "TEMPLATES": getattr(cls, "TEMPLATES", (("default", "Default"),)),
-                        }
-                        if hasattr(cls, "get_render_template")
-                        else {}
-                    ),
+                    **cls._deprecated_plugin_graft(),
                     "__module__": "djangocms_frontend.cms_plugins",
                 },
             )
@@ -241,13 +242,27 @@ class CMSFrontendComponent(forms.Form):
     def get_short_description(self) -> str:
         return self.config.get("title", "")
 
-    def save_model(self, request, obj, form: forms.Form, change: bool) -> None:
-        """Auto-creates slot plugins upon creation of component plugin instance"""
-        from cms.api import add_plugin
+    #: Plugin attributes that used to be authored directly on the component and
+    #: grafted onto the generated plugin. They now belong in a nested
+    #: ``PluginMixin`` (``save_model``/``get_render_template`` as methods that can
+    #: call ``super()``, ``TEMPLATES`` as a plain attribute). Declaring them on the
+    #: component is deprecated and reported by ``check_component_plugin_behavior``.
+    _DEPRECATED_PLUGIN_ATTRS = ("save_model", "get_render_template", "TEMPLATES")
 
-        from .ui_plugin_base import CMSUIComponent
+    @classmethod
+    def _deprecated_plugin_attrs(cls) -> list[str]:
+        """Names of deprecated plugin attributes declared directly on the
+        component class (used by both the back-compat graft and the system check)."""
+        return [name for name in cls._DEPRECATED_PLUGIN_ATTRS if name in cls.__dict__]
 
-        super(CMSUIComponent, self).save_model(request, obj, form, change)
-        if not change:
-            for slot in self.slots.keys():
-                add_plugin(obj.placeholder, slot, obj.language, target=obj)
+    @classmethod
+    def _deprecated_plugin_graft(cls) -> dict:
+        """Back-compat shim: graft plugin attributes still declared directly on
+        the component class onto the generated plugin.
+
+        New code should declare these in a nested ``PluginMixin`` class so they
+        live in the plugin's MRO and can use ``super()`` instead of relying on the
+        factory to copy them across. The deprecated usage is surfaced via the
+        system check framework (see ``apps.check_component_plugin_behavior``).
+        """
+        return {name: cls.__dict__[name] for name in cls._deprecated_plugin_attrs()}

--- a/djangocms_frontend/component_pool.py
+++ b/djangocms_frontend/component_pool.py
@@ -115,6 +115,7 @@ class CMSAutoComponentDiscovery:
 
 class Components:
     _registry: dict = {}
+    _components: dict = {}
     _discovered: bool = False
 
     def register(self, component):
@@ -122,6 +123,7 @@ class Components:
             warnings.warn(f"Component {component.__name__} already registered", stacklevel=2)
             return component
         self._registry[component.__name__] = component.get_registration()
+        self._components[component.__name__] = component
         return component
 
     def __getitem__(self, item):

--- a/djangocms_frontend/ui_plugin_base.py
+++ b/djangocms_frontend/ui_plugin_base.py
@@ -93,5 +93,5 @@ class CMSUIComponent(CMSUIPluginBase):
 
         super().save_model(request, obj, form, change)
         if not change:
-            for slot in getattr(self, "slots", {}).keys():
+            for slot in self.slots:
                 add_plugin(obj.placeholder, slot, obj.language, target=obj)

--- a/djangocms_frontend/ui_plugin_base.py
+++ b/djangocms_frontend/ui_plugin_base.py
@@ -83,4 +83,15 @@ class CMSUIPluginBase(FrontendEditableAdminMixin, CMSPluginBase):
 
 
 class CMSUIComponent(CMSUIPluginBase):
-    pass
+    def save_model(self, request, obj, form, change):
+        """Auto-create slot plugins when a component plugin instance is created.
+
+        This is the component default. A component's nested ``PluginMixin`` can
+        extend it by calling ``super().save_model(...)``.
+        """
+        from cms.api import add_plugin
+
+        super().save_model(request, obj, form, change)
+        if not change:
+            for slot in getattr(self, "slots", {}).keys():
+                add_plugin(obj.placeholder, slot, obj.language, target=obj)

--- a/docs/source/tutorial/custom_components.rst
+++ b/docs/source/tutorial/custom_components.rst
@@ -340,14 +340,56 @@ For more details on the setting, see
 Limitations of custom frontend components
 =========================================
 
-Custom frontend components are a powerful tool for developers, but they have a limitations:
+Custom frontend components are a powerful tool for developers, but they have some limitations:
 
 **Limited Python code**: Custom components are (indirect) subclasses of Django's ``AdminForm`` class
-and can contain Python code to modify the behavior of a form. You cannot directly add Python code to
-the resulting plugin class with the exception of ``get_render_template()``. Similarly, you cannot add
-Python code the model class, in this case with the exception of ``get_short_description()``.
+and can contain Python code to modify the behavior of a form. To add behavior to the *plugin* class
+itself -- such as ``save_model()`` or ``get_render_template()`` -- declare a nested ``PluginMixin``
+class (see below). You cannot add Python code to the model class, with the exception of
+``get_short_description()``.
 
-For maximun flexibility in your customized components, you can build a :ref:`custom Plugin<how-to-add-frontend-plugins>`.
+For maximum flexibility in your customized components, you can build a :ref:`custom Plugin<how-to-add-frontend-plugins>`.
+
+
+Plugin-side behavior with ``PluginMixin``
+=========================================
+
+A component declaration describes a *form*. Behavior that belongs to the generated CMS *plugin* --
+methods such as ``save_model()`` or ``get_render_template()`` -- goes into a nested ``PluginMixin``
+class. Its methods and attributes are mixed into the plugin's bases, so it behaves like a normal
+mixin and can call ``super()``:
+
+.. code-block:: python
+
+    from cms.api import add_plugin
+
+
+    @components.register
+    class CTAPanel(CMSFrontendComponent):
+        class Meta:
+            name = "CTA Panel"
+            render_template = "cta.html"
+
+        main_heading = forms.CharField()
+
+        class PluginMixin:
+            def save_model(self, request, obj, form, change):
+                super().save_model(request, obj, form, change)
+                if not change:
+                    add_plugin(
+                        obj.placeholder, "TextLinkPlugin", obj.language, target=obj, config={...}
+                    )
+
+Because ``PluginMixin`` sits in the plugin's method-resolution order, ``super().save_model(...)``
+reaches the component default (which auto-creates any slot plugins) and then django CMS's own
+``save_model()``. Attributes such as ``TEMPLATES`` and methods such as ``get_render_template()`` can
+be declared here too.
+
+.. deprecated:: 2.5
+    Declaring ``save_model()``, ``get_render_template()`` or ``TEMPLATES`` directly on the component
+    class is deprecated. They are still grafted onto the plugin for backwards compatibility, and the
+    deprecated usage is reported by ``manage.py check`` (``djangocms_frontend.W003``). Support will be
+    removed in a future release -- move them into a nested ``PluginMixin`` class instead.
 
 
 Conclusion

--- a/tests/component/test_checks.py
+++ b/tests/component/test_checks.py
@@ -64,23 +64,32 @@ class DeprecatedPluginBehaviorCheckTestCase(SimpleTestCase):
             def save_model(self, request, obj, form, change):
                 pass
 
-        # Reported in declaration order, ``get_render_template`` is absent here.
-        self.assertEqual(OldStyle._deprecated_plugin_attrs(), ["save_model", "TEMPLATES"])
+            def get_render_template(self, context, instance, placeholder):
+                return "custom.html"
 
-        # The factory still grafts them for backwards compatibility.
+        # Reported in the order of ``_DEPRECATED_PLUGIN_ATTRS``.
+        self.assertEqual(
+            OldStyle._deprecated_plugin_attrs(),
+            ["save_model", "get_render_template", "TEMPLATES"],
+        )
+
+        # The factory still grafts them all for backwards compatibility.
         plugin = OldStyle.plugin_factory()
         self.assertIn("save_model", plugin.__dict__)
+        self.assertIn("get_render_template", plugin.__dict__)
         self.assertEqual(plugin.__dict__["TEMPLATES"], (("z", "Z"),))
+        self.assertEqual(plugin().get_render_template({}, None, None), "custom.html")
 
+        self.addCleanup(components._components.pop, "OldStyleComponent", None)
         components._components["OldStyleComponent"] = OldStyle
-        try:
-            warnings = check_component_plugin_behavior()
-        finally:
-            components._components.pop("OldStyleComponent", None)
+        warnings = check_component_plugin_behavior()
 
         match = [w for w in warnings if w.obj.endswith("OldStyle")]
         self.assertEqual(len(match), 1)
         self.assertEqual(match[0].id, "djangocms_frontend.W003")
+        # All deprecated attributes are named in the warning.
+        for attr in ("save_model", "get_render_template", "TEMPLATES"):
+            self.assertIn(attr, match[0].msg)
 
     def test_plugin_mixin_is_not_flagged(self):
         class Clean(CMSFrontendComponent):
@@ -97,3 +106,9 @@ class DeprecatedPluginBehaviorCheckTestCase(SimpleTestCase):
                     super().save_model(request, obj, form, change)
 
         self.assertEqual(Clean._deprecated_plugin_attrs(), [])
+
+        # The system check itself produces no warning for the component.
+        self.addCleanup(components._components.pop, "CleanComponent", None)
+        components._components["CleanComponent"] = Clean
+        warnings = check_component_plugin_behavior()
+        self.assertEqual([w for w in warnings if w.obj.endswith("Clean")], [])

--- a/tests/component/test_checks.py
+++ b/tests/component/test_checks.py
@@ -1,0 +1,99 @@
+from django import forms
+from django.test import SimpleTestCase
+
+from djangocms_frontend.apps import check_component_plugin_behavior
+from djangocms_frontend.component_base import CMSFrontendComponent
+from djangocms_frontend.component_pool import components
+from djangocms_frontend.ui_plugin_base import CMSUIComponent
+
+
+class PluginMixinTestCase(SimpleTestCase):
+    """The nested ``PluginMixin`` is mixed into the plugin's bases."""
+
+    def test_plugin_mixin_sits_before_base_in_mro(self):
+        class WithMixin(CMSFrontendComponent):
+            __module__ = "tests.test_app.cms_components"
+
+            class Meta:
+                name = "WithMixinComponent"
+                render_template = "x.html"
+
+            title = forms.CharField()
+
+            class PluginMixin:
+                def get_render_template(self, context, instance, placeholder):
+                    return "custom.html"
+
+        plugin = WithMixin.plugin_factory()
+        mro = plugin.__mro__
+
+        self.assertIn(WithMixin.PluginMixin, mro)
+        # Before CMSUIComponent, so ``super()`` reaches the component defaults.
+        self.assertLess(mro.index(WithMixin.PluginMixin), mro.index(CMSUIComponent))
+        self.assertEqual(plugin().get_render_template({}, None, None), "custom.html")
+
+    def test_no_plugin_mixin_uses_base_defaults(self):
+        class Plain(CMSFrontendComponent):
+            __module__ = "tests.test_app.cms_components"
+
+            class Meta:
+                name = "PlainComponent"
+                render_template = "x.html"
+
+            title = forms.CharField()
+
+        plugin = Plain.plugin_factory()
+        # The slot-creating default lives on CMSUIComponent and is inherited.
+        self.assertIs(plugin.save_model, CMSUIComponent.save_model)
+
+
+class DeprecatedPluginBehaviorCheckTestCase(SimpleTestCase):
+    """``check_component_plugin_behavior`` reports legacy top-level declarations."""
+
+    def test_attrs_declared_on_component_are_detected(self):
+        class OldStyle(CMSFrontendComponent):
+            __module__ = "tests.test_app.cms_components"
+
+            class Meta:
+                name = "OldStyleComponent"
+                render_template = "x.html"
+
+            title = forms.CharField()
+            TEMPLATES = (("z", "Z"),)
+
+            def save_model(self, request, obj, form, change):
+                pass
+
+        # Reported in declaration order, ``get_render_template`` is absent here.
+        self.assertEqual(OldStyle._deprecated_plugin_attrs(), ["save_model", "TEMPLATES"])
+
+        # The factory still grafts them for backwards compatibility.
+        plugin = OldStyle.plugin_factory()
+        self.assertIn("save_model", plugin.__dict__)
+        self.assertEqual(plugin.__dict__["TEMPLATES"], (("z", "Z"),))
+
+        components._components["OldStyleComponent"] = OldStyle
+        try:
+            warnings = check_component_plugin_behavior()
+        finally:
+            components._components.pop("OldStyleComponent", None)
+
+        match = [w for w in warnings if w.obj.endswith("OldStyle")]
+        self.assertEqual(len(match), 1)
+        self.assertEqual(match[0].id, "djangocms_frontend.W003")
+
+    def test_plugin_mixin_is_not_flagged(self):
+        class Clean(CMSFrontendComponent):
+            __module__ = "tests.test_app.cms_components"
+
+            class Meta:
+                name = "CleanComponent"
+                render_template = "x.html"
+
+            title = forms.CharField()
+
+            class PluginMixin:
+                def save_model(self, request, obj, form, change):
+                    super().save_model(request, obj, form, change)
+
+        self.assertEqual(Clean._deprecated_plugin_attrs(), [])

--- a/tests/component/test_plugins.py
+++ b/tests/component/test_plugins.py
@@ -140,6 +140,20 @@ class ComponentPluginTestCase(TestFixture, CMSTestCase):
         self.assertEqual(plugins[2].plugin_type, MyHeroSlotPlugin.__name__)
         self.assertEqual(plugins[2].parent.pk, instance.pk)
 
+    def test_no_slots_created_on_change(self):
+        # Editing an existing plugin (change=True) must not re-create slots.
+        instance = add_plugin(
+            placeholder=self.placeholder,
+            plugin_type=MyHeroPlugin.__name__,
+            language=self.language,
+        )
+        request = self.get_request(path="/")
+        MyHeroPlugin().save_model(request=request, obj=instance, form=MyHeroPlugin.form, change=True)
+
+        plugins = list(self.placeholder.get_plugins())
+        self.assertEqual(len(plugins), 1)
+        self.assertEqual(plugins[0].plugin_type, MyHeroPlugin.__name__)
+
     def test_simple_component_plugin(self):
         instance = add_plugin(
             placeholder=self.placeholder,


### PR DESCRIPTION
## Summary by Sourcery

Introduce a nested PluginMixin pattern for frontend components to encapsulate plugin behavior and add checks and defaults around this new structure.

Enhancements:
- Mix nested PluginMixin classes into generated CMS plugins so plugin behavior lives in the MRO instead of being grafted as standalone attributes.
- Provide a default save_model implementation on CMSUIComponent that auto-creates slot plugins for new component instances.
- Track registered component classes in the component pool for later inspection and behavior checks.
- Add a system check that reports components still declaring plugin behavior directly on the component class and provide a backwards-compatibility graft for those attributes.

Tests:
- Add tests covering PluginMixin integration with generated plugins and the deprecation check for legacy component-level plugin behavior.