### PR TITLE
chore: Prepare release 2.5.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+2.5.1 (2026-07-08)
+==================
+
+* fix: Component child classes falsely set to [] instead of None by @fsbraun in https://github.com/django-cms/djangocms-frontend/pull/386
+
 2.5.0 (2026-06-29)
 ==================
 

--- a/djangocms_frontend/__init__.py
+++ b/djangocms_frontend/__init__.py
@@ -19,4 +19,4 @@ Release logic:
 13. Github actions will publish the new package to pypi
 """
 
-__version__ = "2.5.0"
+__version__ = "2.5.1"


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Update the library version constant from 2.5.0 to 2.5.1.