### PR TITLE
fix: Conform to the documentation and automatically set allow_children if child classes are specified

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -24,6 +24,7 @@ jobs:
             dj51_cms41.txt,
             dj52_cms50.txt,
             dj60_cms50.txt,
+            dj60_cms51.txt,
         ]
         os: [
             ubuntu-latest,
@@ -43,6 +44,10 @@ jobs:
             requirements-file: dj60_cms50.txt
           - python-version: "3.11"
             requirements-file: dj60_cms50.txt
+          - python-version: "3.10"
+            requirements-file: dj60_cms51.txt
+          - python-version: "3.11"
+            requirements-file: dj60_cms51.txt
           # Python 3.12 and 3.13 don't support Django 4.2 with CMS 3.11
           - python-version: "3.12"
             requirements-file: dj42_cms311.txt

--- a/djangocms_frontend/component_base.py
+++ b/djangocms_frontend/component_base.py
@@ -181,7 +181,7 @@ class CMSFrontendComponent(forms.Form):
                     "module": getattr(cls._component_meta, "module", _("Components")),
                     "model": cls.plugin_model_factory(),
                     "form": cls.admin_form_factory(),
-                    "allow_children": slots or getattr(cls._component_meta, "allow_children", False),
+                    "allow_children": slots or getattr(cls._component_meta, "allow_children", bool(child_classes)),
                     "child_classes": child_classes,
                     "render_template": getattr(cls._component_meta, "render_template", CMSUIComponent.render_template),
                     "fieldsets": getattr(cls._component_meta, "fieldsets", cls._generate_fieldset()),

--- a/tests/requirements/dj60_cms51.txt
+++ b/tests/requirements/dj60_cms51.txt
@@ -1,0 +1,6 @@
+-r base.txt
+
+Django>=6.0,<6.1
+django-cms>=5.1,<5.2
+djangocms-versioning>=2.4
+


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure allow_children defaults to True when child_classes are specified, even if not explicitly set in component metadata.
- fixes #389 